### PR TITLE
optionally allow Proc for interval

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 .bundle
 Gemfile.lock
 pkg/*
+.idea

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.3.3.1
+* Allow sleep parameter to be a proc/lambda to allow for exponential backoff.
+
 ## 1.3.3
 * sleep after executing the retry block, so there's no wait on the first call (molfar)
 

--- a/README.md
+++ b/README.md
@@ -87,6 +87,15 @@ retriable :interval => (200/1000.0), :timeout => (500/1000.0) do
 end
 ```
 
+If you'd like exponential backoff, interval can take a Proc
+
+```ruby
+# with exponential back-off - sleep 4, 16, 64, 256, give up
+retryable :times => 4, :interval => lambda {|attempts| 4 ** attempts} do
+  # code here...
+end
+```
+
 Retriable also provides a callback called `:on_retry` that will run after an exception is rescued. This callback provides the number of `tries`, and the `exception` that was raised in the current attempt. As these are specified in a `Proc`, unnecessary variables can be left out of the parameter list.
 
 ```ruby

--- a/lib/retriable/retriable.rb
+++ b/lib/retriable/retriable.rb
@@ -35,7 +35,10 @@ module Retriable
         if @tries > 0
           count += 1
           @on_retry.call(exception, count) if @on_retry
-          sleep @interval if @interval > 0
+
+          sleep_for = @interval.respond_to?(:call) ? @interval.call(count) : @interval
+          sleep sleep_for if sleep_for > 0
+
           retry
         else
           raise

--- a/lib/retriable/version.rb
+++ b/lib/retriable/version.rb
@@ -1,5 +1,5 @@
 # encoding: utf-8
 
 module Retriable
-  VERSION = '1.3.3'
+  VERSION = '1.3.3.1'
 end

--- a/test/retriable_test.rb
+++ b/test/retriable_test.rb
@@ -43,4 +43,19 @@ class RetriableTest < MiniTest::Unit::TestCase
   rescue ArgumentError
     assert_equal 5, i
   end
+
+  def test_with_interval_proc
+    was_called = false
+
+    sleeper = Proc.new do |attempts|
+      was_called = true
+      attempts
+    end
+
+    retriable :on => EOFError, :interval => sleeper do |h|
+      raise EOFError.new
+    end
+  rescue
+    assert_equal was_called, true
+  end
 end


### PR DESCRIPTION
This allows for exponential backoff. Inspired by justeat/retryable.
