### PR TITLE
allow for an `:on` parameter that includes a regexp

### DIFF
--- a/lib/retriable.rb
+++ b/lib/retriable.rb
@@ -44,6 +44,8 @@ module Retriable
       rand_factor: rand_factor
     ).intervals
 
+    filter = rescue_filter(on)
+
     intervals.each.with_index(1) do |interval, attempt|
       begin
         if timeout
@@ -51,11 +53,29 @@ module Retriable
         else
           return block.call(attempt)
         end
-      rescue *[*on] => exception
+      rescue *[*rescue_klasses(on)] => exception
+        raise if filter[exception.class] && exception.message !~ filter[exception.class]
         on_retry.call(exception, attempt, Time.now - start_time, interval) if on_retry
         raise if attempt >= max_tries || (elapsed_time.call + interval) > max_elapsed_time
         sleep interval if config.sleep_disabled != true
       end
+    end
+  end
+
+  private
+
+  def rescue_klasses(on)
+    Array(on).map do |element|
+      element.is_a?(Hash) ? element[:klass] : element
+    end
+  end
+
+  def rescue_filter(on)
+    Array(on).inject({}) do |h, element|
+      if element.is_a?(Hash)
+        h[element[:klass]] = element[:regex]
+      end
+      h
     end
   end
 end

--- a/spec/retriable_spec.rb
+++ b/spec/retriable_spec.rb
@@ -52,6 +52,28 @@ describe Retriable do
       end.must_raise TestError
     end
 
+    it "re-raises immediately when given a regex that does not match" do
+      -> do
+        @attempts = 0
+        subject.retry(on: [{klass: TestError, regex: /foo bar/}]) do
+          @attempts += 1
+          raise TestError.new("no match")
+        end
+      end.must_raise TestError
+      @attempts.must_equal 1
+    end
+
+    it "retries when given a regex that does" do
+      -> do
+        @attempts = 0
+        subject.retry(on: [{klass: TestError, regex: /match/}]) do
+          @attempts += 1
+          raise TestError.new("does match")
+        end
+      end.must_raise TestError
+      @attempts.must_equal 3
+    end
+
     it "retry with 10 max tries" do
       attempts = 0
 


### PR DESCRIPTION
useful for matching where libraries raise overly opaque errors and one must match on messages.
