### PR TITLE
Add ruby 1.9.3 support

### DIFF
--- a/lib/retriable.rb
+++ b/lib/retriable.rb
@@ -16,18 +16,17 @@ module Retriable
     @config ||= Config.new
   end
 
-  def retriable(
-      tries:             config.tries,
-      base_interval:     config.base_interval,
-      max_interval:      config.max_interval,
-      rand_factor:       config.rand_factor,
-      multiplier:        config.multiplier,
-      max_elapsed_time:  config.max_elapsed_time,
-      intervals:         config.intervals,
-      timeout:           config.timeout,
-      on:                config.on,
-      on_retry:          config.on_retry
-    )
+  def retriable(opts = {})
+    tries             = opts[:tries]            || config.tries
+    base_interval     = opts[:base_interval]    || config.base_interval
+    max_interval      = opts[:max_interval]     || config.max_interval
+    rand_factor       = opts[:rand_factor]      || config.rand_factor
+    multiplier        = opts[:multiplier]       || config.multiplier
+    max_elapsed_time  = opts[:max_elapsed_time] || config.max_elapsed_time
+    intervals         = opts[:intervals]        || config.intervals
+    timeout           = opts[:timeout]          || config.timeout
+    on                = opts[:on]               || config.on
+    on_retry          = opts[:on_retry]         || config.on_retry
 
     start_time = Time.now
     elapsed_time = -> { Time.now - start_time }

--- a/lib/retriable/core_ext/kernel.rb
+++ b/lib/retriable/core_ext/kernel.rb
@@ -1,7 +1,7 @@
 require "retriable"
 
 module Kernel
-  def retriable(opts={}, &block)
+  def retriable(opts = {}, &block)
     Retriable.retriable(opts, &block)
   end
 end

--- a/lib/retriable/exponential_backoff.rb
+++ b/lib/retriable/exponential_backoff.rb
@@ -6,19 +6,12 @@ module Retriable
     attr_accessor :max_interval
     attr_accessor :rand_factor
 
-    def initialize(
-        tries:            Retriable.config.tries,
-        base_interval:    Retriable.config.base_interval,
-        multiplier:       Retriable.config.multiplier,
-        max_interval:     Retriable.config.max_interval,
-        rand_factor:      Retriable.config.rand_factor
-      )
-
-      @tries          = tries
-      @base_interval  = base_interval
-      @multiplier     = multiplier
-      @max_interval   = max_interval
-      @rand_factor    = rand_factor
+    def initialize(opts = {})
+      @tries         = opts[:tries]         || Retriable.config.tries
+      @base_interval = opts[:base_interval] || Retriable.config.base_interval
+      @max_interval  = opts[:max_interval]  || Retriable.config.max_interval
+      @rand_factor   = opts[:rand_factor]   || Retriable.config.rand_factor
+      @multiplier    = opts[:multiplier]    || Retriable.config.multiplier
     end
 
     def intervals


### PR DESCRIPTION
I mainly dropped 1.9.3 support so I could start using some 2.x+ features like named parameters. I also thought most rubyists had migrated to at least 2.0, which is 3 versions back and now 2 years old. However, it seems there's a decent chunk of people still using 1.9.3, and I don't think having named parameters is worth 1.9.3 support yet. I'll likely revert this commit when support for 1.9.3 is finally dropped.