### PR TITLE
Use ruby version aliases in Travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,12 @@
+# Send builds to container-based infrastructure
+# http://docs.travis-ci.com/user/workers/container-based-infrastructure/
+sudo: false
 language: ruby
 rvm:
   - 1.9.3
-  - 2.0.0
-  - 2.1.5
-  - 2.2.1
+  - 2.0
+  - 2.1
+  - 2.2
   - rbx
   - ruby-head
   - jruby-head


### PR DESCRIPTION
This will tell Travis to always use the latest version with specified minor version. 
Remove the need of updating patch level version number.

Also add `sudo: true` for faster build