### PR TITLE
Travis: Test on latest stable JRuby 9.1.7.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ rvm:
   - 2.4.0
   - rbx
   - jruby-9.0.5.0
-  - jruby-9.1.6.0
+  - jruby-9.1.7.0
   - ruby-head
   - jruby-head
 


### PR DESCRIPTION
This PR updates JRuby in the test matrix to the latest stable release.