### PR TITLE
Add validation; refactor main #retriable method over to Config#retriable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@
 *.o
 *.a
 mkmf.log
+.DS_Store
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## HEAD
 
+## 3.1.0-prerelease
+* Allow value of `:on` to be a single exception class (instead of either an array or hash)
+* Add strict validation
+
 ## 3.0.1
 * Add `rubocop` linter to enforce coding styles for this library. Also, fix rule violations.
 * Removed `attr_reader :config` that caused a warning. @bruno-

--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,6 @@ source "https://rubygems.org"
 gemspec
 
 group :test do
-  # gem "ruby_gntp"
   gem "codeclimate-test-reporter", require: false
   gem "minitest-focus"
   gem "simplecov", require: false

--- a/README.md
+++ b/README.md
@@ -68,38 +68,30 @@ end
 
 Here are the available options:
 
-`tries` (default: 3) - Number of attempts to make at running your code block (includes intial attempt).
+| Option | Default | Definition |
+| ------ | ------- | ---------- |
+| **`tries`** | `3` | Number of attempts to make at running your code block (includes intial attempt). |
+| **`base_interval`** | `0.5` | The initial interval in seconds between tries. |
+| **`max_interval`** | `60` | The maximum interval in seconds that any try can reach. |
+| **`rand_factor`** | 0.25 | The percent range above and below the next interval is randomized between. The calculation is calculated as `randomized_interval = retry_interval * (random value in range [1 - randomization_factor, 1 + randomization_factor])` |
+| **`multiplier`** | `1.5` | Each successive interval grows by this factor. A multipler of 1.5 means the next interval will be 1.5x the current interval. |
+| **`max_elapsed_time`** | `900` (15 min) | The maximum amount of total time that code is allowed to keep being retried. |
+| **`intervals`** | `nil` | Skip generated intervals and provide your own array of intervals in seconds. *Setting this option will ignore `tries`, `base_interval`, `max_interval`, `rand_factor`, and `multiplier` values.* |
+| **`timeout`** | `nil` | Number of seconds to allow the code block to run before raising a `Timeout::Error` inside each try. `nil` means the code block can run forever without raising error. |
+| **`on`** | `[StandardError]` | See below. |
+| **`on_retry`** | `nil` | Proc to call after each try is rescued. |
 
-`base_interval` (default: 0.5) - The initial interval in seconds between tries.
+#### Configuring Which Options to Retry With :on
+**`:on`** Can take the form:
 
-`max_interval` (default: 60) - The maximum interval in seconds that any try can reach.
-
-`rand_factor` (default: 0.25) - The percent range above and below the next interval is randomized between. The calculation is calculated like this:
-
-```
-randomized_interval = retry_interval * (random value in range [1 - randomization_factor, 1 + randomization_factor])
-```
-
-`multiplier` (default: 1.5) - Each successive interval grows by this factor. A multipler of 1.5 means the next interval will be 1.5x the current interval.
-
-`max_elapsed_time`  (default: 900 (15 min)) - The maximum amount of total time that code is allowed to keep being retried.
-
-`intervals`  (default: nil) - Skip generated intervals and provide your own array of intervals in seconds. Setting this option will ignore `tries`, `base_interval`, `max_interval`, `rand_factor`, and `multiplier` values.
-
-`timeout` (default: nil) - Number of seconds to allow the code block to run before raising a `Timeout::Error` inside each try. Default is `nil` means the code block can run forever without raising error.
-
-`on` (default: [StandardError]) - One of:
-
-1. An `Exception` class
-1. An `Array` of `Exception` classes to rescue for each try
+1. An `Exception` class (retry every exception of this type, including subclasses)
+1. An `Array` of `Exception` classes (retry any exception of one of these types, including subclasses)
 1. A `Hash` where the keys are `Exception` classes and the values are one of:
-  1. `nil` (retries everything that is a subclass of the key)
-  1. A single `Regexp` pattern (retries exceptions that are subclasses of the key ONLY if they match the pattern)
-  1. An array of patterns (retries exceptions that are subclasses of the key ONLY if they match the pattern)
+  1. `nil`(retry every exception of the key's type, including subclasses)
+  1. A single `Regexp` pattern (retries exceptions ONLY if they match the pattern)
+  1. An array of patterns (retries exceptions ONLY if they match at least one of the patterns)
 
-`on_retry` - (default: nil) - Proc to call after each try is rescued.
-
-### Config
+### Configuring Defaults
 
 You can change the global defaults with a `#configure` block:
 
@@ -108,6 +100,8 @@ Retriable.configure do |c|
   c.tries = 5
   c.max_elapsed_time = 3600 # 1 hour
 end
+
+(The configurable defaults are exactly the same as the options)
 ```
 
 ### Examples

--- a/README.md
+++ b/README.md
@@ -88,7 +88,14 @@ randomized_interval = retry_interval * (random value in range [1 - randomization
 
 `timeout` (default: nil) - Number of seconds to allow the code block to run before raising a `Timeout::Error` inside each try. Default is `nil` means the code block can run forever without raising error.
 
-`on` (default: [StandardError]) - An `Array` of exceptions to rescue for each try, a `Hash` where the keys are `Exception` classes and the values can be a single `Regexp` pattern or a list of patterns, or a single `Exception` type. Subclasses of the listed exceptions will be retried and have their messages matched in the same way.
+`on` (default: [StandardError]) - One of:
+
+1. An `Exception` class
+1. An `Array` of `Exception` classes to rescue for each try
+1. A `Hash` where the keys are `Exception` classes and the values are one of:
+  1. `nil` (retries everything that is a subclass of the key)
+  1. A single `Regexp` pattern (retries exceptions that are subclasses of the key ONLY if they match the pattern)
+  1. An array of patterns (retries exceptions that are subclasses of the key ONLY if they match the pattern)
 
 `on_retry` - (default: nil) - Proc to call after each try is rescued.
 

--- a/lib/retriable.rb
+++ b/lib/retriable.rb
@@ -6,60 +6,21 @@ require_relative "retriable/version"
 module Retriable
   module_function
 
-  def self.configure
+  def configure
     yield(config)
+    config.validate!
   end
 
   def config
     @config ||= Config.new
   end
 
-  def retriable(opts = {})
-    tries             = opts[:tries]            || config.tries
-    base_interval     = opts[:base_interval]    || config.base_interval
-    max_interval      = opts[:max_interval]     || config.max_interval
-    rand_factor       = opts[:rand_factor]      || config.rand_factor
-    multiplier        = opts[:multiplier]       || config.multiplier
-    max_elapsed_time  = opts[:max_elapsed_time] || config.max_elapsed_time
-    intervals         = opts[:intervals]        || config.intervals
-    timeout           = opts[:timeout]          || config.timeout
-    on                = opts[:on]               || config.on
-    on_retry          = opts[:on_retry]         || config.on_retry
+  def reset!
+    @config = Config.new
+  end
 
-    start_time = Time.now
-    elapsed_time = -> { Time.now - start_time }
-
-    if intervals
-      tries = intervals.size + 1
-    else
-      intervals = ExponentialBackoff.new(
-        tries:          tries - 1,
-        base_interval:  base_interval,
-        multiplier:     multiplier,
-        max_interval:   max_interval,
-        rand_factor:    rand_factor,
-      ).intervals
-    end
-
-    exception_list = on.is_a?(Hash) ? on.keys : on
-
-    tries.times do |index|
-      try = index + 1
-      begin
-        return Timeout.timeout(timeout) { return yield(try) } if timeout
-        return yield(try)
-      rescue *[*exception_list] => exception
-        if on.is_a?(Hash)
-          raise unless exception_list.any? do |e|
-            exception.is_a?(e) && ([*on[e]].empty? || [*on[e]].any? { |pattern| exception.message =~ pattern })
-          end
-        end
-
-        interval = intervals[index]
-        on_retry.call(exception, try, elapsed_time.call, interval) if on_retry
-        raise if try >= tries || (elapsed_time.call + interval) > max_elapsed_time
-        sleep interval if config.sleep_disabled != true
-      end
-    end
+  def retriable(opts = {}, &block)
+    raise ArgumentError, 'retriable options must be a hash' unless opts && opts.is_a?(Hash)
+    config.dup.retriable(opts, &block)
   end
 end

--- a/lib/retriable.rb
+++ b/lib/retriable.rb
@@ -1,6 +1,6 @@
 require "timeout"
-require_relative "retriable/config"
 require_relative "retriable/exponential_backoff"
+require_relative "retriable/config"
 require_relative "retriable/version"
 
 module Retriable

--- a/lib/retriable/config.rb
+++ b/lib/retriable/config.rb
@@ -40,13 +40,14 @@ module Retriable
       end
 
       validate!
+
       start_time = Time.now
       elapsed_time = -> { Time.now - start_time }
 
       if intervals
         @tries = intervals.size + 1
       else
-        intervals = ExponentialBackoff.new(
+        @intervals = ExponentialBackoff.new(
           tries:          tries - 1,
           base_interval:  base_interval,
           multiplier:     multiplier,
@@ -72,7 +73,7 @@ module Retriable
           interval = intervals[index]
           on_retry.call(exception, try, elapsed_time.call, interval) if on_retry
           raise if try >= tries || (elapsed_time.call + interval) > max_elapsed_time
-          sleep interval if sleep_disabled != true
+          sleep(interval) if sleep_disabled != true
         end
       end
     end

--- a/lib/retriable/config.rb
+++ b/lib/retriable/config.rb
@@ -49,8 +49,11 @@ module Retriable
         try = index + 1
 
         begin
-          return Timeout.timeout(timeout) { return yield(try) } if timeout
-          return yield(try)
+          if timeout
+            return Timeout.timeout(timeout) { yield(try) }
+          else
+            return yield(try)
+          end
         rescue *[*exception_list] => exception
           if on.is_a?(Hash)
             raise unless exception_list.any? do |e|

--- a/lib/retriable/config.rb
+++ b/lib/retriable/config.rb
@@ -6,7 +6,7 @@ module Retriable
       :max_interval,
       :multiplier,
       :rand_factor,
-      :timeout,      
+      :timeout,
       :tries
     ].freeze
 
@@ -47,13 +47,7 @@ module Retriable
       if intervals
         @tries = intervals.size + 1
       else
-        @intervals = ExponentialBackoff.new(
-          tries:          tries - 1,
-          base_interval:  base_interval,
-          multiplier:     multiplier,
-          max_interval:   max_interval,
-          rand_factor:    rand_factor,
-        ).intervals
+        @intervals = ExponentialBackoff.new(to_h).intervals
       end
 
       tries.times do |index|
@@ -109,6 +103,12 @@ module Retriable
 
     def valid_exception?(e)
       e.is_a?(Class) && e < Exception
+    end
+
+    def to_h
+      hash = PROPERTIES.inject({}) { |hsh, prop| hsh.merge(prop => public_send(prop)) }
+      hash[:tries] -= 1 if hash[:tries]
+      hash
     end
   end
 end

--- a/lib/retriable/config.rb
+++ b/lib/retriable/config.rb
@@ -39,6 +39,7 @@ module Retriable
       validate!
       start_time = Time.now
       elapsed_time = -> { Time.now - start_time }
+      exception_list = on.is_a?(Hash) ? on.keys : on
 
       if intervals
         @tries = intervals.size + 1
@@ -51,8 +52,6 @@ module Retriable
           rand_factor:    rand_factor,
         ).intervals
       end
-
-      exception_list = on.is_a?(Hash) ? on.keys : on
 
       tries.times do |index|
         try = index + 1

--- a/lib/retriable/config.rb
+++ b/lib/retriable/config.rb
@@ -59,6 +59,7 @@ module Retriable
 
       tries.times do |index|
         try = index + 1
+
         begin
           return Timeout.timeout(timeout) { return yield(try) } if timeout
           return yield(try)

--- a/lib/retriable/config.rb
+++ b/lib/retriable/config.rb
@@ -1,16 +1,20 @@
 module Retriable
   class Config
-    attr_accessor :sleep_disabled
-    attr_accessor :tries
-    attr_accessor :base_interval
-    attr_accessor :max_interval
-    attr_accessor :rand_factor
-    attr_accessor :multiplier
-    attr_accessor :max_elapsed_time
-    attr_accessor :intervals
-    attr_accessor :timeout
-    attr_accessor :on
-    attr_accessor :on_retry
+    PROPERTIES = [
+      :base_interval,
+      :intervals,
+      :max_elapsed_time,
+      :max_interval,
+      :multiplier,
+      :on,
+      :on_retry,
+      :rand_factor,
+      :sleep_disabled,
+      :timeout,
+      :tries
+    ]
+
+    PROPERTIES.each { |p| attr_accessor p }
 
     def initialize
       @sleep_disabled    = false
@@ -24,6 +28,77 @@ module Retriable
       @timeout           = nil
       @on                = [StandardError]
       @on_retry          = nil
+    end
+
+    def retriable(opts = {})
+      opts.each do |k, v|
+        raise ArgumentError, "#{k} => #{v} is not a valid configuration" unless PROPERTIES.include?(k)
+      end
+
+      PROPERTIES.each do |property|
+        public_send("#{property}=", opts[property] || public_send(property))
+      end
+
+      validate!
+      start_time = Time.now
+      elapsed_time = -> { Time.now - start_time }
+
+      if intervals
+        @tries = intervals.size + 1
+      else
+        intervals = ExponentialBackoff.new(
+          tries:          tries - 1,
+          base_interval:  base_interval,
+          multiplier:     multiplier,
+          max_interval:   max_interval,
+          rand_factor:    rand_factor,
+        ).intervals
+      end
+
+      exception_list = on.is_a?(Hash) ? on.keys : on
+
+      tries.times do |index|
+        try = index + 1
+        begin
+          return Timeout.timeout(timeout) { return yield(try) } if timeout
+          return yield(try)
+        rescue *[*exception_list] => exception
+          if on.is_a?(Hash)
+            raise unless exception_list.any? do |e|
+              exception.is_a?(e) && ([*on[e]].empty? || [*on[e]].any? { |pattern| exception.message =~ pattern })
+            end
+          end
+
+          interval = intervals[index]
+          on_retry.call(exception, try, elapsed_time.call, interval) if on_retry
+          raise if try >= tries || (elapsed_time.call + interval) > max_elapsed_time
+          sleep interval if sleep_disabled != true
+        end
+      end
+    end
+
+    def validate!
+      if on.is_a?(Array)
+        raise ArgumentError, invalid_config_message(:on) unless on.all? { |e| e < Exception }
+      elsif on.is_a?(Hash)
+        on.each do |k, v|
+          raise ArgumentError, "'#{k}' is not an Exception" unless k < Exception
+          next if v.nil? || v.is_a?(Regexp)
+          raise ArgumentError, invalid_config_message(:on) unless v.is_a?(Array) && v.all? { |rgx| rgx.is_a?(Regexp) }
+        end
+      elsif !on.is_a?(Exception)
+        raise ArgumentError, invalid_config_message(:on)
+      end
+
+      if intervals && !intervals.is_a?(Array)
+        raise ArgumentError, invalid_config_message(:intervals)
+      end
+    end
+
+    private
+
+    def invalid_config_message(param)
+      "Invalid configuration of #{param}: #{public_send(param)}"
     end
   end
 end

--- a/lib/retriable/config.rb
+++ b/lib/retriable/config.rb
@@ -2,8 +2,7 @@ module Retriable
   class Config
     NUMERIC_PROPERTIES = ExponentialBackoff::PROPERTIES + [
       :max_elapsed_time,
-      :timeout,
-      :tries
+      :timeout
     ].freeze
 
     PROPERTIES = NUMERIC_PROPERTIES + [

--- a/lib/retriable/config.rb
+++ b/lib/retriable/config.rb
@@ -97,6 +97,8 @@ module Retriable
       NUMERIC_PROPERTIES.each do |option|
         raise_invalid_config_message(option) if public_send(option) && !public_send(option).is_a?(Numeric)
       end
+
+      raise_invalid_config_message(:on_retry) if on_retry && !on_retry.is_a?(Proc)
     end
 
     private

--- a/lib/retriable/config.rb
+++ b/lib/retriable/config.rb
@@ -1,14 +1,6 @@
 module Retriable
   class Config
-    EXPONENTIAL_BACKOFF_PROPERTIES = [
-      :base_interval,
-      :max_interval,
-      :multiplier,
-      :rand_factor,
-      :tries
-    ].freeze
-
-    NUMERIC_PROPERTIES = EXPONENTIAL_BACKOFF_PROPERTIES + [
+    NUMERIC_PROPERTIES = ExponentialBackoff::PROPERTIES + [
       :max_elapsed_time,
       :timeout,
       :tries
@@ -110,7 +102,7 @@ module Retriable
     end
 
     def backoff_options
-      hash = EXPONENTIAL_BACKOFF_PROPERTIES.inject({}) { |hsh, prop| hsh.merge(prop => public_send(prop)) }
+      hash = ExponentialBackoff::PROPERTIES.inject({}) { |hsh, prop| hsh.merge(prop => public_send(prop)) }
       hash[:tries] -= 1 if hash[:tries]
       hash
     end

--- a/lib/retriable/config.rb
+++ b/lib/retriable/config.rb
@@ -86,7 +86,7 @@ module Retriable
           next if v.nil? || v.is_a?(Regexp)
           raise ArgumentError, invalid_config_message(:on) unless v.is_a?(Array) && v.all? { |rgx| rgx.is_a?(Regexp) }
         end
-      elsif !on.is_a?(Exception)
+      elsif !(on < Exception)
         raise ArgumentError, invalid_config_message(:on)
       end
 

--- a/lib/retriable/config.rb
+++ b/lib/retriable/config.rb
@@ -6,6 +6,7 @@ module Retriable
       :max_interval,
       :multiplier,
       :rand_factor,
+      :timeout,      
       :tries
     ].freeze
 
@@ -13,8 +14,7 @@ module Retriable
       :intervals,
       :on,
       :on_retry,
-      :sleep_disabled,
-      :timeout
+      :sleep_disabled
     ].freeze
 
     PROPERTIES.each { |p| attr_accessor p }

--- a/lib/retriable/config.rb
+++ b/lib/retriable/config.rb
@@ -40,7 +40,6 @@ module Retriable
       end
 
       validate!
-
       start_time = Time.now
       elapsed_time = -> { Time.now - start_time }
 
@@ -80,14 +79,14 @@ module Retriable
 
     def validate!
       if on.is_a?(Array)
-        raise ArgumentError, invalid_config_message(:on) unless on.all? { |e| e < Exception }
+        raise ArgumentError, invalid_config_message(:on) unless on.all? { |e| valid_exception?(e) }
       elsif on.is_a?(Hash)
         on.each do |k, v|
-          raise ArgumentError, "'#{k}' is not an Exception" unless k < Exception
+          raise ArgumentError, "'#{k}' is not an Exception" unless valid_exception?(k)
           next if v.nil? || v.is_a?(Regexp)
           raise ArgumentError, invalid_config_message(:on) unless v.is_a?(Array) && v.all? { |rgx| rgx.is_a?(Regexp) }
         end
-      elsif !(on < Exception)
+      elsif !valid_exception?(on)
         raise ArgumentError, invalid_config_message(:on)
       end
 
@@ -100,6 +99,10 @@ module Retriable
 
     def invalid_config_message(param)
       "Invalid configuration of #{param}: #{public_send(param)}"
+    end
+
+    def valid_exception?(e)
+      e.is_a?(Class) && e < Exception
     end
   end
 end

--- a/lib/retriable/config.rb
+++ b/lib/retriable/config.rb
@@ -1,18 +1,21 @@
 module Retriable
   class Config
-    PROPERTIES = [
+    NUMERIC_PROPERTIES = [
       :base_interval,
-      :intervals,
       :max_elapsed_time,
       :max_interval,
       :multiplier,
+      :rand_factor,
+      :tries
+    ].freeze
+
+    PROPERTIES = NUMERIC_PROPERTIES + [
+      :intervals,
       :on,
       :on_retry,
-      :rand_factor,
       :sleep_disabled,
-      :timeout,
-      :tries
-    ]
+      :timeout
+    ].freeze
 
     PROPERTIES.each { |p| attr_accessor p }
 
@@ -91,7 +94,7 @@ module Retriable
         raise_invalid_config_message(:intervals)
       end
 
-      [:tries, :base_interval, :max_interval, :rand_factor, :multiplier, :max_elapsed_time].each do |option|
+      NUMERIC_PROPERTIES.each do |option|
         raise_invalid_config_message(option) if public_send(option) && !public_send(option).is_a?(Numeric)
       end
     end

--- a/lib/retriable/config.rb
+++ b/lib/retriable/config.rb
@@ -33,10 +33,7 @@ module Retriable
     def retriable(opts = {})
       opts.each do |k, v|
         raise ArgumentError, "#{k} => #{v} is not a valid option" unless PROPERTIES.include?(k)
-      end
-
-      PROPERTIES.each do |property|
-        public_send("#{property}=", opts[property] || public_send(property))
+        public_send("#{k}=", v) if v
       end
 
       validate!

--- a/lib/retriable/exponential_backoff.rb
+++ b/lib/retriable/exponential_backoff.rb
@@ -1,17 +1,17 @@
 module Retriable
   class ExponentialBackoff
-    attr_accessor :tries
-    attr_accessor :base_interval
-    attr_accessor :multiplier
-    attr_accessor :max_interval
-    attr_accessor :rand_factor
+    PROPERTIES = [
+      :base_interval,
+      :max_interval,
+      :multiplier,
+      :rand_factor,
+      :tries
+    ].freeze
+
+    PROPERTIES.each { |p| attr_accessor p }
 
     def initialize(opts = {})
-      @tries         = opts[:tries]         || Retriable.config.tries
-      @base_interval = opts[:base_interval] || Retriable.config.base_interval
-      @max_interval  = opts[:max_interval]  || Retriable.config.max_interval
-      @rand_factor   = opts[:rand_factor]   || Retriable.config.rand_factor
-      @multiplier    = opts[:multiplier]    || Retriable.config.multiplier
+      PROPERTIES.each { |p| public_send("#{p}=", opts[p] || Retriable.config.public_send(p)) }
     end
 
     def intervals

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -5,6 +5,10 @@ describe Retriable::Config do
     Retriable::Config
   end
 
+  after do
+    Retriable.reset!
+  end
+
   it "sleep defaults to enabled" do
     expect(subject.new.sleep_disabled).must_equal false
   end
@@ -43,5 +47,19 @@ describe Retriable::Config do
 
   it "on retry handler defaults to nil" do
     expect(subject.new.on_retry).must_be_nil
+  end
+
+  it "raises errors on invalid configuration" do
+    assert_raises ArgumentError do
+      Retriable.configure { |c| c.on = 1234 }
+    end
+
+    assert_raises ArgumentError do
+      Retriable.configure { |c| c.on = { StandardError => StandardError } }
+    end
+
+    assert_raises ArgumentError do
+      Retriable.configure { |c| c.on = { StandardError => [1, 2] } }
+    end
   end
 end

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -69,5 +69,9 @@ describe Retriable::Config do
     assert_raises ArgumentError do
       Retriable.configure { |c| c.on = { StandardError => [1, 2] } }
     end
+
+    assert_raises ArgumentError do
+      Retriable.configure { |c| c.on_retry = '1234' }
+    end
   end
 end

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -51,6 +51,14 @@ describe Retriable::Config do
 
   it "raises errors on invalid configuration" do
     assert_raises ArgumentError do
+      Retriable.configure { |c| c.max_interval = '123' }
+    end
+
+    assert_raises ArgumentError do
+      Retriable.configure { |c| c.tries = '123' }
+    end
+
+    assert_raises ArgumentError do
       Retriable.configure { |c| c.on = 1234 }
     end
 

--- a/spec/retriable_spec.rb
+++ b/spec/retriable_spec.rb
@@ -11,6 +11,10 @@ describe Retriable do
     srand 0
   end
 
+  after do
+    Retriable.reset!
+  end
+
   describe "with sleep disabled" do
     before do
       Retriable.configure do |c|

--- a/spec/retriable_spec.rb
+++ b/spec/retriable_spec.rb
@@ -222,7 +222,7 @@ describe Retriable do
           intervals: intervals,
         ) do
           try_count += 1
-          raise StandardError.new, "StandardError occurred"
+          raise StandardError, "StandardError occurred"
         end
       end.must_raise StandardError
 

--- a/spec/retriable_spec.rb
+++ b/spec/retriable_spec.rb
@@ -247,7 +247,7 @@ describe Retriable do
         end
       end.must_raise TestError
 
-      expect(tries).must_equal(10)
+      expect(tries).must_equal(3)
       expect(e.message).must_equal "something went wrong"
     end
 

--- a/spec/retriable_spec.rb
+++ b/spec/retriable_spec.rb
@@ -56,7 +56,7 @@ describe Retriable do
       expect do
         subject.retriable do
           tries += 1
-          raise TestError.new, "TestError occurred"
+          raise TestError, "TestError occurred"
         end
       end.must_raise TestError
 
@@ -69,7 +69,7 @@ describe Retriable do
       expect do
         subject.retriable on: TestError do
           tries += 1
-          raise TestError.new, "TestError occurred"
+          raise TestError, "TestError occurred"
         end
       end.must_raise TestError
 
@@ -239,12 +239,15 @@ describe Retriable do
     end
 
     it "#retriable with a hash exception where the value is an exception message pattern" do
+      tries = 0
       e = expect do
         subject.retriable on: { TestError => /something went wrong/ } do
+          tries += 1
           raise TestError, "something went wrong"
         end
       end.must_raise TestError
 
+      expect(tries).must_equal(10)
       expect(e.message).must_equal "something went wrong"
     end
 


### PR DESCRIPTION
@kamui take a look at this - based on [the discussion about validation](https://github.com/kamui/retriable/pull/29/files#r101904862)

I ended up refactoring the main `retriable` method into `Config` to avoid having to validate the initial configuration as well as the options to `retriable` in separate files - now all the validation is just in the `Config` class, which also controls the options for the `retriable` call.  (Worked out better than I expected going into the refactor)

Also wondering if there's any more validation you'd like to see?  Or just other comments.

p.s. `ActiveModel` has a really great approach for basic validation like this and if this weren't a bare bones "use anywhere" absolute-minimum-dependencies style critical path gem i would suggest it, but as it is i feel like locking `Retriable` to `ActiveSupport` in any way would cause a lot of dependency pain in the user base.