### PR TITLE
Contexts feature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@
 *.o
 *.a
 mkmf.log
+.DS_Store
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## HEAD
 
+## 3.1.0-prerelease
+* Allow value of `:on` to be a single exception class (instead of either an array or hash)
+* Add strict validation
+
 ## 3.0.1
 * Add `rubocop` linter to enforce coding styles for this library. Also, fix rule violations.
 * Removed `attr_reader :config` that caused a warning. @bruno-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## HEAD
 
 ## 3.1.0-prerelease
+* Added contexts feature
 * Allow value of `:on` to be a single exception class (instead of either an array or hash)
 * Add strict validation
 

--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,6 @@ source "https://rubygems.org"
 gemspec
 
 group :test do
-  # gem "ruby_gntp"
   gem "codeclimate-test-reporter", require: false
   gem "minitest-focus"
   gem "simplecov", require: false

--- a/README.md
+++ b/README.md
@@ -88,7 +88,14 @@ randomized_interval = retry_interval * (random value in range [1 - randomization
 
 `timeout` (default: nil) - Number of seconds to allow the code block to run before raising a `Timeout::Error` inside each try. Default is `nil` means the code block can run forever without raising error.
 
-`on` (default: [StandardError]) - An `Array` of exceptions to rescue for each try, a `Hash` where the keys are `Exception` classes and the values can be a single `Regexp` pattern or a list of patterns, or a single `Exception` type. Subclasses of the listed exceptions will be retried and have their messages matched in the same way.
+`on` (default: [StandardError]) - One of:
+
+1. An `Exception` class
+1. An `Array` of `Exception` classes to rescue for each try
+1. A `Hash` where the keys are `Exception` classes and the values are one of:
+  1. `nil` (retries everything that is a subclass of the key)
+  1. A single `Regexp` pattern (retries exceptions that are subclasses of the key ONLY if they match the pattern)
+  1. An array of patterns (retries exceptions that are subclasses of the key ONLY if they match the pattern)
 
 `on_retry` - (default: nil) - Proc to call after each try is rescued.
 

--- a/README.md
+++ b/README.md
@@ -253,7 +253,7 @@ Retriable.mysql do
 end
 ```
 
-You can even temporarily override a configured context:
+You can even temporarily override individual options for a configured context:
 
 ```ruby
 Retriable.mysql(tries: 30) do

--- a/lib/retriable.rb
+++ b/lib/retriable.rb
@@ -1,7 +1,7 @@
 require 'timeout'
-require_relative File.join('retriable', 'exponential_backoff')
-require_relative File.join('retriable', 'config')
-require_relative File.join('retriable', 'version')
+require 'retriable/exponential_backoff'
+require 'retriable/config'
+require 'retriable/version'
 
 module Retriable
   module_function

--- a/lib/retriable.rb
+++ b/lib/retriable.rb
@@ -6,60 +6,21 @@ require_relative "retriable/version"
 module Retriable
   module_function
 
-  def self.configure
+  def configure
     yield(config)
+    config.validate!
   end
 
   def config
     @config ||= Config.new
   end
 
-  def retriable(opts = {})
-    tries             = opts[:tries]            || config.tries
-    base_interval     = opts[:base_interval]    || config.base_interval
-    max_interval      = opts[:max_interval]     || config.max_interval
-    rand_factor       = opts[:rand_factor]      || config.rand_factor
-    multiplier        = opts[:multiplier]       || config.multiplier
-    max_elapsed_time  = opts[:max_elapsed_time] || config.max_elapsed_time
-    intervals         = opts[:intervals]        || config.intervals
-    timeout           = opts[:timeout]          || config.timeout
-    on                = opts[:on]               || config.on
-    on_retry          = opts[:on_retry]         || config.on_retry
+  def reset!
+    @config = Config.new
+  end
 
-    start_time = Time.now
-    elapsed_time = -> { Time.now - start_time }
-
-    if intervals
-      tries = intervals.size + 1
-    else
-      intervals = ExponentialBackoff.new(
-        tries:          tries - 1,
-        base_interval:  base_interval,
-        multiplier:     multiplier,
-        max_interval:   max_interval,
-        rand_factor:    rand_factor,
-      ).intervals
-    end
-
-    exception_list = on.is_a?(Hash) ? on.keys : on
-
-    tries.times do |index|
-      try = index + 1
-      begin
-        return Timeout.timeout(timeout) { return yield(try) } if timeout
-        return yield(try)
-      rescue *[*exception_list] => exception
-        if on.is_a?(Hash)
-          raise unless exception_list.any? do |e|
-            exception.is_a?(e) && ([*on[e]].empty? || [*on[e]].any? { |pattern| exception.message =~ pattern })
-          end
-        end
-
-        interval = intervals[index]
-        on_retry.call(exception, try, elapsed_time.call, interval) if on_retry
-        raise if try >= tries || (elapsed_time.call + interval) > max_elapsed_time
-        sleep interval if config.sleep_disabled != true
-      end
-    end
+  def retriable(opts = {}, &block)
+    raise ArgumentError, 'retriable options must be a hash' unless opts && opts.is_a?(Hash)
+    config.dup.retriable(opts, &block)
   end
 end

--- a/lib/retriable.rb
+++ b/lib/retriable.rb
@@ -1,7 +1,7 @@
-require "timeout"
-require_relative "retriable/config"
-require_relative "retriable/exponential_backoff"
-require_relative "retriable/version"
+require 'timeout'
+require_relative File.join('retriable', 'config')
+require_relative File.join('retriable', 'exponential_backoff')
+require_relative File.join('retriable', 'version')
 
 module Retriable
   module_function

--- a/lib/retriable/config.rb
+++ b/lib/retriable/config.rb
@@ -40,13 +40,14 @@ module Retriable
       end
 
       validate!
+
       start_time = Time.now
       elapsed_time = -> { Time.now - start_time }
 
       if intervals
         @tries = intervals.size + 1
       else
-        intervals = ExponentialBackoff.new(
+        @intervals = ExponentialBackoff.new(
           tries:          tries - 1,
           base_interval:  base_interval,
           multiplier:     multiplier,
@@ -72,7 +73,7 @@ module Retriable
           interval = intervals[index]
           on_retry.call(exception, try, elapsed_time.call, interval) if on_retry
           raise if try >= tries || (elapsed_time.call + interval) > max_elapsed_time
-          sleep interval if sleep_disabled != true
+          sleep(interval) if sleep_disabled != true
         end
       end
     end

--- a/lib/retriable/config.rb
+++ b/lib/retriable/config.rb
@@ -6,7 +6,7 @@ module Retriable
       :max_interval,
       :multiplier,
       :rand_factor,
-      :timeout,      
+      :timeout,
       :tries
     ].freeze
 
@@ -19,18 +19,22 @@ module Retriable
 
     PROPERTIES.each { |p| attr_accessor p }
 
-    def initialize
-      @sleep_disabled    = false
-      @tries             = 3
-      @base_interval     = 0.5
-      @max_interval      = 60
-      @rand_factor       = 0.5
-      @multiplier        = 1.5
-      @max_elapsed_time  = 900 # 15 min
-      @intervals         = nil
-      @timeout           = nil
-      @on                = [StandardError]
-      @on_retry          = nil
+    def initialize(opts = {})
+      opts.each do |k, v|
+        raise ArgumentError, "#{k} => #{v} is not a valid option" unless PROPERTIES.include?(k)
+      end
+
+      @sleep_disabled    = opts[:sleep_disabled]   || false
+      @tries             = opts[:tries]            || 3
+      @base_interval     = opts[:base_interval]    || 0.5
+      @max_interval      = opts[:max_interval]     || 60
+      @rand_factor       = opts[:rand_factor]      || 0.5
+      @multiplier        = opts[:multiplier]       || 1.5
+      @max_elapsed_time  = opts[:max_elapsed_time] || 900 # 15 min
+      @intervals         = opts[:interval]         || nil
+      @timeout           = opts[:timeout]          || nil
+      @on                = opts[:on]               || [StandardError]
+      @on_retry          = opts[:on_retry]         || nil
     end
 
     def retriable(opts = {})

--- a/lib/retriable/config.rb
+++ b/lib/retriable/config.rb
@@ -39,6 +39,7 @@ module Retriable
       validate!
       start_time = Time.now
       elapsed_time = -> { Time.now - start_time }
+      exception_list = on.is_a?(Hash) ? on.keys : on
 
       if intervals
         @tries = intervals.size + 1
@@ -51,8 +52,6 @@ module Retriable
           rand_factor:    rand_factor,
         ).intervals
       end
-
-      exception_list = on.is_a?(Hash) ? on.keys : on
 
       tries.times do |index|
         try = index + 1

--- a/lib/retriable/config.rb
+++ b/lib/retriable/config.rb
@@ -59,6 +59,7 @@ module Retriable
 
       tries.times do |index|
         try = index + 1
+
         begin
           return Timeout.timeout(timeout) { return yield(try) } if timeout
           return yield(try)

--- a/lib/retriable/config.rb
+++ b/lib/retriable/config.rb
@@ -1,16 +1,20 @@
 module Retriable
   class Config
-    attr_accessor :sleep_disabled
-    attr_accessor :tries
-    attr_accessor :base_interval
-    attr_accessor :max_interval
-    attr_accessor :rand_factor
-    attr_accessor :multiplier
-    attr_accessor :max_elapsed_time
-    attr_accessor :intervals
-    attr_accessor :timeout
-    attr_accessor :on
-    attr_accessor :on_retry
+    PROPERTIES = [
+      :base_interval,
+      :intervals,
+      :max_elapsed_time,
+      :max_interval,
+      :multiplier,
+      :on,
+      :on_retry,
+      :rand_factor,
+      :sleep_disabled,
+      :timeout,
+      :tries
+    ]
+
+    PROPERTIES.each { |p| attr_accessor p }
 
     def initialize
       @sleep_disabled    = false
@@ -24,6 +28,77 @@ module Retriable
       @timeout           = nil
       @on                = [StandardError]
       @on_retry          = nil
+    end
+
+    def retriable(opts = {})
+      opts.each do |k, v|
+        raise ArgumentError, "#{k} => #{v} is not a valid configuration" unless PROPERTIES.include?(k)
+      end
+
+      PROPERTIES.each do |property|
+        public_send("#{property}=", opts[property] || public_send(property))
+      end
+
+      validate!
+      start_time = Time.now
+      elapsed_time = -> { Time.now - start_time }
+
+      if intervals
+        @tries = intervals.size + 1
+      else
+        intervals = ExponentialBackoff.new(
+          tries:          tries - 1,
+          base_interval:  base_interval,
+          multiplier:     multiplier,
+          max_interval:   max_interval,
+          rand_factor:    rand_factor,
+        ).intervals
+      end
+
+      exception_list = on.is_a?(Hash) ? on.keys : on
+
+      tries.times do |index|
+        try = index + 1
+        begin
+          return Timeout.timeout(timeout) { return yield(try) } if timeout
+          return yield(try)
+        rescue *[*exception_list] => exception
+          if on.is_a?(Hash)
+            raise unless exception_list.any? do |e|
+              exception.is_a?(e) && ([*on[e]].empty? || [*on[e]].any? { |pattern| exception.message =~ pattern })
+            end
+          end
+
+          interval = intervals[index]
+          on_retry.call(exception, try, elapsed_time.call, interval) if on_retry
+          raise if try >= tries || (elapsed_time.call + interval) > max_elapsed_time
+          sleep interval if sleep_disabled != true
+        end
+      end
+    end
+
+    def validate!
+      if on.is_a?(Array)
+        raise ArgumentError, invalid_config_message(:on) unless on.all? { |e| e < Exception }
+      elsif on.is_a?(Hash)
+        on.each do |k, v|
+          raise ArgumentError, "'#{k}' is not an Exception" unless k < Exception
+          next if v.nil? || v.is_a?(Regexp)
+          raise ArgumentError, invalid_config_message(:on) unless v.is_a?(Array) && v.all? { |rgx| rgx.is_a?(Regexp) }
+        end
+      elsif !on.is_a?(Exception)
+        raise ArgumentError, invalid_config_message(:on)
+      end
+
+      if intervals && !intervals.is_a?(Array)
+        raise ArgumentError, invalid_config_message(:intervals)
+      end
+    end
+
+    private
+
+    def invalid_config_message(param)
+      "Invalid configuration of #{param}: #{public_send(param)}"
     end
   end
 end

--- a/lib/retriable/config.rb
+++ b/lib/retriable/config.rb
@@ -2,8 +2,7 @@ module Retriable
   class Config
     NUMERIC_PROPERTIES = ExponentialBackoff::PROPERTIES + [
       :max_elapsed_time,
-      :timeout,
-      :tries
+      :timeout
     ].freeze
 
     PROPERTIES = NUMERIC_PROPERTIES + [

--- a/lib/retriable/config.rb
+++ b/lib/retriable/config.rb
@@ -97,6 +97,8 @@ module Retriable
       NUMERIC_PROPERTIES.each do |option|
         raise_invalid_config_message(option) if public_send(option) && !public_send(option).is_a?(Numeric)
       end
+
+      raise_invalid_config_message(:on_retry) if on_retry && !on_retry.is_a?(Proc)
     end
 
     private

--- a/lib/retriable/config.rb
+++ b/lib/retriable/config.rb
@@ -86,7 +86,7 @@ module Retriable
           next if v.nil? || v.is_a?(Regexp)
           raise ArgumentError, invalid_config_message(:on) unless v.is_a?(Array) && v.all? { |rgx| rgx.is_a?(Regexp) }
         end
-      elsif !on.is_a?(Exception)
+      elsif !(on < Exception)
         raise ArgumentError, invalid_config_message(:on)
       end
 

--- a/lib/retriable/config.rb
+++ b/lib/retriable/config.rb
@@ -20,9 +20,7 @@ module Retriable
     PROPERTIES.each { |p| attr_accessor p }
 
     def initialize(opts = {})
-      opts.each do |k, v|
-        raise ArgumentError, "#{k} => #{v} is not a valid option" unless PROPERTIES.include?(k)
-      end
+      validate_options!(opts)
 
       @sleep_disabled    = opts[:sleep_disabled]   || false
       @tries             = opts[:tries]            || 3
@@ -38,10 +36,8 @@ module Retriable
     end
 
     def retriable(opts = {})
-      opts.each do |k, v|
-        raise ArgumentError, "#{k} => #{v} is not a valid option" unless PROPERTIES.include?(k)
-        public_send("#{k}=", v) if v
-      end
+      validate_options!(opts)
+      opts.each { |k, v| public_send("#{k}=", v) if v }
 
       validate!
       start_time = Time.now
@@ -113,6 +109,12 @@ module Retriable
 
     def valid_exception?(e)
       e.is_a?(Class) && e < Exception
+    end
+
+    def validate_options!(options)
+      options.each do |k, v|
+        raise ArgumentError, "#{k} => #{v} is not a valid option" unless PROPERTIES.include?(k)
+      end
     end
   end
 end

--- a/lib/retriable/config.rb
+++ b/lib/retriable/config.rb
@@ -101,6 +101,7 @@ module Retriable
     end
 
     def validate_options!(options)
+      raise ArgumentError, 'Configuration options must be a hash' unless options.is_a?(Hash)
       options.each do |k, v|
         raise ArgumentError, "#{k} => #{v} is not a valid option" unless PROPERTIES.include?(k)
       end

--- a/lib/retriable/config.rb
+++ b/lib/retriable/config.rb
@@ -6,6 +6,7 @@ module Retriable
       :max_interval,
       :multiplier,
       :rand_factor,
+      :timeout,      
       :tries
     ].freeze
 
@@ -13,8 +14,7 @@ module Retriable
       :intervals,
       :on,
       :on_retry,
-      :sleep_disabled,
-      :timeout
+      :sleep_disabled
     ].freeze
 
     PROPERTIES.each { |p| attr_accessor p }

--- a/lib/retriable/config.rb
+++ b/lib/retriable/config.rb
@@ -40,7 +40,6 @@ module Retriable
       end
 
       validate!
-
       start_time = Time.now
       elapsed_time = -> { Time.now - start_time }
 
@@ -80,14 +79,14 @@ module Retriable
 
     def validate!
       if on.is_a?(Array)
-        raise ArgumentError, invalid_config_message(:on) unless on.all? { |e| e < Exception }
+        raise ArgumentError, invalid_config_message(:on) unless on.all? { |e| valid_exception?(e) }
       elsif on.is_a?(Hash)
         on.each do |k, v|
-          raise ArgumentError, "'#{k}' is not an Exception" unless k < Exception
+          raise ArgumentError, "'#{k}' is not an Exception" unless valid_exception?(k)
           next if v.nil? || v.is_a?(Regexp)
           raise ArgumentError, invalid_config_message(:on) unless v.is_a?(Array) && v.all? { |rgx| rgx.is_a?(Regexp) }
         end
-      elsif !(on < Exception)
+      elsif !valid_exception?(on)
         raise ArgumentError, invalid_config_message(:on)
       end
 
@@ -100,6 +99,10 @@ module Retriable
 
     def invalid_config_message(param)
       "Invalid configuration of #{param}: #{public_send(param)}"
+    end
+
+    def valid_exception?(e)
+      e.is_a?(Class) && e < Exception
     end
   end
 end

--- a/lib/retriable/config.rb
+++ b/lib/retriable/config.rb
@@ -1,18 +1,21 @@
 module Retriable
   class Config
-    PROPERTIES = [
+    NUMERIC_PROPERTIES = [
       :base_interval,
-      :intervals,
       :max_elapsed_time,
       :max_interval,
       :multiplier,
+      :rand_factor,
+      :tries
+    ].freeze
+
+    PROPERTIES = NUMERIC_PROPERTIES + [
+      :intervals,
       :on,
       :on_retry,
-      :rand_factor,
       :sleep_disabled,
-      :timeout,
-      :tries
-    ]
+      :timeout
+    ].freeze
 
     PROPERTIES.each { |p| attr_accessor p }
 
@@ -91,7 +94,7 @@ module Retriable
         raise_invalid_config_message(:intervals)
       end
 
-      [:tries, :base_interval, :max_interval, :rand_factor, :multiplier, :max_elapsed_time].each do |option|
+      NUMERIC_PROPERTIES.each do |option|
         raise_invalid_config_message(option) if public_send(option) && !public_send(option).is_a?(Numeric)
       end
     end

--- a/lib/retriable/config.rb
+++ b/lib/retriable/config.rb
@@ -33,10 +33,7 @@ module Retriable
     def retriable(opts = {})
       opts.each do |k, v|
         raise ArgumentError, "#{k} => #{v} is not a valid option" unless PROPERTIES.include?(k)
-      end
-
-      PROPERTIES.each do |property|
-        public_send("#{property}=", opts[property] || public_send(property))
+        public_send("#{k}=", v) if v
       end
 
       validate!

--- a/lib/retriable/contexts.rb
+++ b/lib/retriable/contexts.rb
@@ -1,6 +1,4 @@
-# JRuby is complaining; try using plain require and not require_relative
-#require_relative File.join('..', 'retriable')
-require 'retriable'
+require_relative File.join('..', 'retriable')
 require_relative File.join('contexts', 'config')
 
 module Retriable

--- a/lib/retriable/contexts.rb
+++ b/lib/retriable/contexts.rb
@@ -1,0 +1,19 @@
+require 'retriable'
+require_relative 'contexts/config'
+
+module Retriable
+  module_function
+
+  def respond_to_missing?(method_sym, options = {}, &block)
+    config.contexts.key?(method_sym) || super
+  end
+
+  def method_missing(method_sym, options = {}, &block)
+    if (context = config.contexts[method_sym])
+      Config.new(context).retriable(options, &block) if block
+      #context.dup.retriable(options, &block) if block
+    else
+      super
+    end
+  end
+end

--- a/lib/retriable/contexts.rb
+++ b/lib/retriable/contexts.rb
@@ -1,5 +1,5 @@
-require 'retriable'
-require_relative 'contexts/config'
+require_relative File.join('..', 'retriable')
+require_relative File.join('contexts', 'config')
 
 module Retriable
   module_function

--- a/lib/retriable/contexts.rb
+++ b/lib/retriable/contexts.rb
@@ -1,5 +1,5 @@
-require_relative File.join('..', 'retriable')
-require_relative File.join('contexts', 'config')
+require 'retriable'
+require 'retriable/contexts/config'
 
 module Retriable
   module_function

--- a/lib/retriable/contexts.rb
+++ b/lib/retriable/contexts.rb
@@ -1,4 +1,6 @@
-require_relative File.join('..', 'retriable')
+# JRuby is complaining; try using plain require and not require_relative
+#require_relative File.join('..', 'retriable')
+require 'retriable'
 require_relative File.join('contexts', 'config')
 
 module Retriable

--- a/lib/retriable/contexts.rb
+++ b/lib/retriable/contexts.rb
@@ -11,7 +11,6 @@ module Retriable
   def method_missing(method_sym, options = {}, &block)
     if (context = config.contexts[method_sym])
       Config.new(context).retriable(options, &block) if block
-      #context.dup.retriable(options, &block) if block
     else
       super
     end

--- a/lib/retriable/contexts/config.rb
+++ b/lib/retriable/contexts/config.rb
@@ -1,0 +1,16 @@
+module Retriable
+  class Config
+    def contexts
+      @contexts ||= {}
+    end
+
+    def contexts=(envs)
+      if envs.is_a?(Hash) && envs.values.all? { |e| e.is_a?(Hash) }
+        envs.each { |_, options| c = self.class.new(options).validate! }
+        @contexts = envs
+      else
+        raise ArgumentError, 'contexts must be a hash of hashes'
+      end
+    end
+  end
+end

--- a/lib/retriable/contexts/config.rb
+++ b/lib/retriable/contexts/config.rb
@@ -1,16 +1,23 @@
 module Retriable
   class Config
     def contexts
-      @contexts ||= {}
+      @contexts ||= Contexts.new
     end
 
     def contexts=(envs)
       if envs.is_a?(Hash) && envs.values.all? { |e| e.is_a?(Hash) }
-        envs.each { |_, options| c = self.class.new(options).validate! }
-        @contexts = envs
+        envs.each { |env, options| contexts[env] = options }
       else
         raise ArgumentError, 'contexts must be a hash of hashes'
       end
     end
+
+    class Contexts < Hash
+      def []=(key, val)
+        Retriable::Config.new(val).validate!
+        super(key, val)
+      end
+    end
+    private_constant :Contexts
   end
 end

--- a/lib/retriable/core_ext/kernel.rb
+++ b/lib/retriable/core_ext/kernel.rb
@@ -1,4 +1,4 @@
-require_relative "../../retriable"
+require_relative File.join('..', '..', 'retriable')
 
 module Kernel
   def retriable(opts = {}, &block)

--- a/lib/retriable/exponential_backoff.rb
+++ b/lib/retriable/exponential_backoff.rb
@@ -16,10 +16,8 @@ module Retriable
 
     def intervals
       intervals = Array.new(tries) do |iteration|
-        [base_interval * multiplier**iteration, max_interval].min
+        [base_interval * multiplier ** iteration, max_interval].min
       end
-
-      return intervals if rand_factor.zero?
 
       intervals.map { |i| randomize(i) }
     end
@@ -27,8 +25,7 @@ module Retriable
     private
 
     def randomize(interval)
-      return interval if rand_factor.zero?
-      delta = rand_factor * interval * 1.0
+      delta = rand_factor * interval
       min = interval - delta
       max = interval + delta
       rand(min..max)

--- a/lib/retriable/version.rb
+++ b/lib/retriable/version.rb
@@ -1,3 +1,3 @@
 module Retriable
-  VERSION = "3.0.1".freeze
+  VERSION = '3.1.0-prerelease'.freeze
 end

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -5,6 +5,10 @@ describe Retriable::Config do
     Retriable::Config
   end
 
+  after do
+    Retriable.reset!
+  end
+
   it "sleep defaults to enabled" do
     expect(subject.new.sleep_disabled).must_equal false
   end
@@ -43,5 +47,19 @@ describe Retriable::Config do
 
   it "on retry handler defaults to nil" do
     expect(subject.new.on_retry).must_be_nil
+  end
+
+  it "raises errors on invalid configuration" do
+    assert_raises ArgumentError do
+      Retriable.configure { |c| c.on = 1234 }
+    end
+
+    assert_raises ArgumentError do
+      Retriable.configure { |c| c.on = { StandardError => StandardError } }
+    end
+
+    assert_raises ArgumentError do
+      Retriable.configure { |c| c.on = { StandardError => [1, 2] } }
+    end
   end
 end

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -69,5 +69,9 @@ describe Retriable::Config do
     assert_raises ArgumentError do
       Retriable.configure { |c| c.on = { StandardError => [1, 2] } }
     end
+
+    assert_raises ArgumentError do
+      Retriable.configure { |c| c.on_retry = '1234' }
+    end
   end
 end

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -51,6 +51,14 @@ describe Retriable::Config do
 
   it "raises errors on invalid configuration" do
     assert_raises ArgumentError do
+      Retriable.configure { |c| c.max_interval = '123' }
+    end
+
+    assert_raises ArgumentError do
+      Retriable.configure { |c| c.tries = '123' }
+    end
+
+    assert_raises ArgumentError do
       Retriable.configure { |c| c.on = 1234 }
     end
 

--- a/spec/contexts_spec.rb
+++ b/spec/contexts_spec.rb
@@ -1,5 +1,5 @@
 require_relative 'spec_helper'
-require_relative "../lib/retriable/contexts"
+require_relative File.join('..', 'lib', 'retriable', 'contexts')
 
 describe Retriable do
   subject do

--- a/spec/contexts_spec.rb
+++ b/spec/contexts_spec.rb
@@ -18,6 +18,10 @@ describe Retriable do
     Retriable.configure do |config|
       config.contexts = { ecs: { max_elapsed_time: 500 } }
     end
+
+    Retriable.configure do |config|
+      config.contexts[:ecs] = { max_elapsed_time: 500 }
+    end
   end
 
   it "raises errors on invalid configuration" do
@@ -25,14 +29,18 @@ describe Retriable do
       Retriable.configure do |config|
         config.contexts = { aws: { yo: 'mtv raps' } }
       end
-      Retriable.aws { 1 + 1 }
     end
 
     assert_raises ArgumentError do
       Retriable.configure do |config|
         config.contexts = { aws: 'yo' }
       end
-      Retriable.aws { 1 + 1 }
+    end
+
+    assert_raises ArgumentError do
+      Retriable.configure do |config|
+        config.contexts[:aws] = 'yo'
+      end
     end
 
     assert_raises ArgumentError do

--- a/spec/contexts_spec.rb
+++ b/spec/contexts_spec.rb
@@ -10,10 +10,6 @@ describe Retriable do
     Retriable.reset!
   end
 
-  after do
-    Retriable.reset!
-  end
-
   it "accepts context configurations" do
     Retriable.configure do |config|
       config.contexts = { ecs: { max_elapsed_time: 500 } }

--- a/spec/contexts_spec.rb
+++ b/spec/contexts_spec.rb
@@ -1,0 +1,108 @@
+require_relative 'spec_helper'
+require_relative "../lib/retriable/contexts"
+
+describe Retriable do
+  subject do
+    Retriable
+  end
+
+  before do
+    Retriable.reset!
+  end
+
+  after do
+    Retriable.reset!
+  end
+
+  it "accepts context configurations" do
+    Retriable.configure do |config|
+      config.contexts = { ecs: { max_elapsed_time: 500 } }
+    end
+  end
+
+  it "raises errors on invalid configuration" do
+    assert_raises ArgumentError do
+      Retriable.configure do |config|
+        config.contexts = { aws: { yo: 'mtv raps' } }
+      end
+      Retriable.aws { 1 + 1 }
+    end
+
+    assert_raises ArgumentError do
+      Retriable.configure do |config|
+        config.contexts = { aws: 'yo' }
+      end
+      Retriable.aws { 1 + 1 }
+    end
+
+    assert_raises ArgumentError do
+      Retriable.configure do |config|
+        config.contexts = 'yo'
+      end
+    end
+  end
+
+  it "additional_contexts can be added" do
+    Retriable.configure do |config|
+      config.contexts = { aws: { max_elapsed_time: 500 } }
+    end
+
+    Retriable.configure do |config|
+      config.contexts[:s3] = { max_elapsed_time: 1500 }
+    end
+
+    Retriable.aws
+    Retriable.s3
+  end
+
+  it 'will not use a nonexistent context' do
+    expect do
+      Retriable.heroku do
+        tries += 1
+        raise EOFError.new
+      end
+    end.must_raise NoMethodError
+  end
+
+  it 'uses a configured context' do
+    tries = 0
+
+    subject.configure do |c|
+      c.contexts[:aws] = {
+        base_interval: 0.1,
+        multiplier: 0.1,
+        tries: 5
+      }
+    end
+
+    expect do
+      Retriable.aws do
+        tries += 1
+        raise EOFError
+      end
+    end.must_raise EOFError
+
+    expect(tries).must_equal(5)
+  end
+
+  it 'overloads part of a configured context' do
+    tries = 0
+
+    subject.configure do |c|
+      c.contexts[:aws] = {
+        base_interval: 0.1,
+        multiplier: 0.1,
+        tries: 5
+      }
+    end
+
+    expect do
+      Retriable.aws(tries: 10) do
+        tries += 1
+        raise EOFError
+      end
+    end.must_raise EOFError
+
+    expect(tries).must_equal(10)
+  end
+end

--- a/spec/retriable_spec.rb
+++ b/spec/retriable_spec.rb
@@ -11,6 +11,10 @@ describe Retriable do
     srand 0
   end
 
+  after do
+    Retriable.reset!
+  end
+
   describe "with sleep disabled" do
     before do
       Retriable.configure do |c|

--- a/spec/retriable_spec.rb
+++ b/spec/retriable_spec.rb
@@ -222,7 +222,7 @@ describe Retriable do
           intervals: intervals,
         ) do
           try_count += 1
-          raise StandardError.new, "StandardError occurred"
+          raise StandardError, "StandardError occurred"
         end
       end.must_raise StandardError
 

--- a/spec/retriable_spec.rb
+++ b/spec/retriable_spec.rb
@@ -247,7 +247,7 @@ describe Retriable do
         end
       end.must_raise TestError
 
-      expect(tries).must_equal(10)
+      expect(tries).must_equal(3)
       expect(e.message).must_equal "something went wrong"
     end
 

--- a/spec/retriable_spec.rb
+++ b/spec/retriable_spec.rb
@@ -56,7 +56,7 @@ describe Retriable do
       expect do
         subject.retriable do
           tries += 1
-          raise TestError.new, "TestError occurred"
+          raise TestError, "TestError occurred"
         end
       end.must_raise TestError
 
@@ -69,7 +69,7 @@ describe Retriable do
       expect do
         subject.retriable on: TestError do
           tries += 1
-          raise TestError.new, "TestError occurred"
+          raise TestError, "TestError occurred"
         end
       end.must_raise TestError
 
@@ -239,12 +239,15 @@ describe Retriable do
     end
 
     it "#retriable with a hash exception where the value is an exception message pattern" do
+      tries = 0
       e = expect do
         subject.retriable on: { TestError => /something went wrong/ } do
+          tries += 1
           raise TestError, "something went wrong"
         end
       end.must_raise TestError
 
+      expect(tries).must_equal(10)
       expect(e.message).must_equal "something went wrong"
     end
 


### PR DESCRIPTION
@kamui - 

This replaces https://github.com/kamui/retriable/pull/29 but is built off of the changes in https://github.com/kamui/retriable/pull/32 - in other words, most of these commits are just from https://github.com/kamui/retriable/pull/29.  [The comparison view over on our fork](https://github.com/lumoslabs/retriable/compare/add_validation...lumoslabs:new_contexts?expand=1) will show you exactly what's going on here  were you to have already merged https://github.com/kamui/retriable/pull/29 (answer: not much at all really, once the validation was factored out).

It also now has the `require` namespaced the way you suggested (which I agree is better).