### PR TITLE
Travis: use jruby-9.1.8.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ rvm:
   - 2.4.0
   - rbx
   - jruby-9.0.5.0
-  - jruby-9.1.7.0
+  - jruby-9.1.8.0
   - ruby-head
   - jruby-head
 


### PR DESCRIPTION
This PR updates to latest stable JRuby in Travis.