### PR TITLE
Add configuration and options validation

### DIFF
--- a/lib/retriable.rb
+++ b/lib/retriable.rb
@@ -15,16 +15,19 @@ module Retriable
   end
 
   def retriable(opts = {})
-    tries             = opts[:tries]            || config.tries
-    base_interval     = opts[:base_interval]    || config.base_interval
-    max_interval      = opts[:max_interval]     || config.max_interval
-    rand_factor       = opts[:rand_factor]      || config.rand_factor
-    multiplier        = opts[:multiplier]       || config.multiplier
-    max_elapsed_time  = opts[:max_elapsed_time] || config.max_elapsed_time
-    intervals         = opts[:intervals]        || config.intervals
-    timeout           = opts[:timeout]          || config.timeout
-    on                = opts[:on]               || config.on
-    on_retry          = opts[:on_retry]         || config.on_retry
+    local_config = opts.empty? ? config : Config.new(config.to_h.merge(opts))
+
+    tries             = local_config.tries
+    base_interval     = local_config.base_interval
+    max_interval      = local_config.max_interval
+    rand_factor       = local_config.rand_factor
+    multiplier        = local_config.multiplier
+    max_elapsed_time  = local_config.max_elapsed_time
+    intervals         = local_config.intervals
+    timeout           = local_config.timeout
+    on                = local_config.on
+    on_retry          = local_config.on_retry
+    sleep_disabled    = local_config.sleep_disabled
 
     start_time = Time.now
     elapsed_time = -> { Time.now - start_time }
@@ -58,7 +61,7 @@ module Retriable
         interval = intervals[index]
         on_retry.call(exception, try, elapsed_time.call, interval) if on_retry
         raise if try >= tries || (elapsed_time.call + interval) > max_elapsed_time
-        sleep interval if config.sleep_disabled != true
+        sleep interval if sleep_disabled != true
       end
     end
   end

--- a/lib/retriable/config.rb
+++ b/lib/retriable/config.rb
@@ -2,12 +2,7 @@ require_relative "exponential_backoff"
 
 module Retriable
   class Config
-    ATTRIBUTES = [
-      :tries,
-      :base_interval,
-      :max_interval,
-      :rand_factor,
-      :multiplier,
+    ATTRIBUTES = ExponentialBackoff::ATTRIBUTES + [
       :sleep_disabled,
       :max_elapsed_time,
       :intervals,

--- a/lib/retriable/config.rb
+++ b/lib/retriable/config.rb
@@ -1,29 +1,48 @@
+require_relative "exponential_backoff"
+
 module Retriable
   class Config
-    attr_accessor :sleep_disabled
-    attr_accessor :tries
-    attr_accessor :base_interval
-    attr_accessor :max_interval
-    attr_accessor :rand_factor
-    attr_accessor :multiplier
-    attr_accessor :max_elapsed_time
-    attr_accessor :intervals
-    attr_accessor :timeout
-    attr_accessor :on
-    attr_accessor :on_retry
+    ATTRIBUTES = [
+      :tries,
+      :base_interval,
+      :max_interval,
+      :rand_factor,
+      :multiplier,
+      :sleep_disabled,
+      :max_elapsed_time,
+      :intervals,
+      :timeout,
+      :on,
+      :on_retry,
+    ].freeze
 
-    def initialize
-      @sleep_disabled    = false
-      @tries             = 3
-      @base_interval     = 0.5
-      @max_interval      = 60
-      @rand_factor       = 0.5
-      @multiplier        = 1.5
-      @max_elapsed_time  = 900 # 15 min
-      @intervals         = nil
-      @timeout           = nil
-      @on                = [StandardError]
-      @on_retry          = nil
+    attr_accessor(*ATTRIBUTES)
+
+    def initialize(opts = {})
+      backoff = ExponentialBackoff.new
+
+      @tries            = backoff.tries
+      @base_interval    = backoff.base_interval
+      @max_interval     = backoff.max_interval
+      @rand_factor      = backoff.rand_factor
+      @multiplier       = backoff.multiplier
+      @sleep_disabled   = false
+      @max_elapsed_time = 900 # 15 min
+      @intervals        = nil
+      @timeout          = nil
+      @on               = [StandardError]
+      @on_retry         = nil
+
+      opts.each do |k, v|
+        raise ArgumentError, "#{k} is not a valid option" if !ATTRIBUTES.include?(k)
+        instance_variable_set(:"@#{k}", v)
+      end
+    end
+
+    def to_h
+      ATTRIBUTES.each_with_object({}) do |key, hash|
+        hash[key] = public_send(key)
+      end
     end
   end
 end

--- a/lib/retriable/exponential_backoff.rb
+++ b/lib/retriable/exponential_backoff.rb
@@ -1,17 +1,26 @@
 module Retriable
   class ExponentialBackoff
-    attr_accessor :tries
-    attr_accessor :base_interval
-    attr_accessor :multiplier
-    attr_accessor :max_interval
-    attr_accessor :rand_factor
+    ATTRIBUTES = [
+      :tries,
+      :base_interval,
+      :multiplier,
+      :max_interval,
+      :rand_factor,
+    ].freeze
+
+    attr_accessor(*ATTRIBUTES)
 
     def initialize(opts = {})
-      @tries         = opts[:tries]         || Retriable.config.tries
-      @base_interval = opts[:base_interval] || Retriable.config.base_interval
-      @max_interval  = opts[:max_interval]  || Retriable.config.max_interval
-      @rand_factor   = opts[:rand_factor]   || Retriable.config.rand_factor
-      @multiplier    = opts[:multiplier]    || Retriable.config.multiplier
+      @tries         = 3
+      @base_interval = 0.5
+      @max_interval  = 60
+      @rand_factor   = 0.5
+      @multiplier    = 1.5
+
+      opts.each do |k, v|
+        raise ArgumentError, "#{k} is not a valid option" if !ATTRIBUTES.include?(k)
+        instance_variable_set(:"@#{k}", v)
+      end
     end
 
     def intervals

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -44,4 +44,10 @@ describe Retriable::Config do
   it "on retry handler defaults to nil" do
     expect(subject.new.on_retry).must_be_nil
   end
+
+  it "raises errors on invalid configuration" do
+    assert_raises ArgumentError do
+      subject.new(does_not_exist: 123)
+    end
+  end
 end

--- a/spec/retriable_spec.rb
+++ b/spec/retriable_spec.rb
@@ -364,4 +364,16 @@ describe Retriable do
 
     expect(tries).must_equal 2
   end
+
+  it "raises NoMethodError on invalid configuration" do
+    assert_raises NoMethodError do
+      Retriable.configure { |c| c.does_not_exist = 123 }
+    end
+  end
+
+  it "raises ArgumentError on invalid option on #retriable" do
+    assert_raises ArgumentError do
+      Retriable.retriable(does_not_exist: 123)
+    end
+  end
 end


### PR DESCRIPTION
Spawned from https://github.com/kamui/retriable/pull/32

I was looking at that PR and I do think validation would be nice, just as a verification that you set things up correctly. I wanted to try and take a different route and focus on these things, some spawned from that PR and some triggered when I was looking at the existing code:

1. `Config` should be instantiable with different options, not just return defaults.
2. `ExponentialBackoff` should be standalone and shouldn't inherit defaults from `Config`. If backoff and config share config, backoff should define it's own defaults and config should use those, not the other way around.
3. I don't want to move retriable logic into `Config`, `Config` should only be focused on configuration and not retriable logic.
4. If options are passed into `retriable` they should instantiate a new `Config` object, merged from the global options.
5. While type validations are nice, I think it adds too much complexity, I wanted to keep it simple. Does the config attribute exist? If so, it's up to the user to set it correctly. If not, then raise an exception. In `configure` it'll raise a `NoMethodError` since it's trying to call call `some_config=` method which won't exist, in `initialize` it'll raise `ArgumentError` since it's validating the options hash.