### PR TITLE
Travis: jruby-9.1.12.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ rvm:
   - 2.4.1
   - rbx
   - jruby-9.0.5.0
-  - jruby-9.1.8.0
+  - jruby-9.1.10.0
   - ruby-head
   - jruby-head
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ rvm:
   - 2.4.1
   - rbx
   - jruby-9.0.5.0
-  - jruby-9.1.10.0
+  - jruby-9.1.12.0
   - ruby-head
   - jruby-head
 


### PR DESCRIPTION
This PR updates the CI matrix to use latest JRuby.

http://jruby.org/2017/06/15/jruby-9-1-12-0.html