### PR TITLE
Set hound line length to 120

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -29,7 +29,7 @@ Metrics/ModuleLength:
   Enabled: false
 
 Metrics/LineLength:
-  Enabled: false
+  Max: 120
 
 Metrics/MethodLength:
   Enabled: false


### PR DESCRIPTION
For some reason hound isn't respecting the `Enable: False` here (see hound comments in #55 and #54)... Might as well try to explicitly set it to 120, which is the standard github view size.