### PR TITLE
Organize MiniTest tests to pass on JRuby - WIP stalled

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ rvm:
   - 2.4.2
   - ruby-head
   - jruby-9.0.5.0
-  - jruby-9.1.13.0
+  - jruby-9.1.15.0
   - jruby-head
   - rbx-3.86
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ before_install:
   - gem update --system
   - gem install bundler
 script:
-  - "bundle exec ruby spec/test_all.rb"
+  - "bin/test_all.sh"
 cache:
   bundler: true
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,12 @@ matrix:
 before_install:
   - gem update --system
   - gem install bundler
+script:
+  - "ruby spec/test_all.rb"
 
+env:
+  global:
+    - JRUBY_OPTS=--debug
 addons:
   code_climate:
     repo_token: 20a1139ef1830b4f813a10a03d90e8aa179b5226f75e75c5a949b25756ebf558

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ before_install:
   - gem update --system
   - gem install bundler
 script:
-  - "ruby spec/test_all.rb"
+  - "bundle exec ruby spec/test_all.rb"
 cache:
   bundler: true
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,14 +18,14 @@ rvm:
 matrix:
   allow_failures:
     - rvm: rbx-3.86
-    - rvm: ruby-head
-    - rvm: jruby-head
 
 before_install:
   - gem update --system
   - gem install bundler
 script:
   - "ruby spec/test_all.rb"
+cache:
+  bundler: true
 
 env:
   global:

--- a/bin/test_all.sh
+++ b/bin/test_all.sh
@@ -2,7 +2,7 @@
 
 HAS_JRUBY=$(ruby -v | grep -o jruby)
 if [[ $HAS_JRUBY = "jruby"  ]]; then
-  ruby -I vendor/bundle spec/test_all.rb
+  JRUBY_OPTS="--debug" jruby -I vendor/bundle spec/test_all.rb
 else
   bundle exec ruby spec/test_all.rb
 fi

--- a/bin/test_all.sh
+++ b/bin/test_all.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+HAS_JRUBY=$(ruby -v | grep -o jruby)
+if [[ $HAS_JRUBY = "jruby"  ]]; then
+  ruby spec/test_all.rb
+else
+  bundle exec ruby spec/test_all.rb
+fi

--- a/bin/test_all.sh
+++ b/bin/test_all.sh
@@ -2,7 +2,7 @@
 
 HAS_JRUBY=$(ruby -v | grep -o jruby)
 if [[ $HAS_JRUBY = "jruby"  ]]; then
-  ruby spec/test_all.rb
+  ruby -I vendor/bundle spec/test_all.rb
 else
   bundle exec ruby spec/test_all.rb
 fi

--- a/bin/test_all.sh
+++ b/bin/test_all.sh
@@ -2,7 +2,8 @@
 
 HAS_JRUBY=$(ruby -v | grep -o jruby)
 if [[ $HAS_JRUBY = "jruby"  ]]; then
-  JRUBY_OPTS="--debug" jruby -I vendor/bundle spec/test_all.rb
+  echo "Using ${BUNDLE_PATH:-vendor/bundle} for an include path"
+  JRUBY_OPTS="--debug" jruby -I "${BUNDLE_PATH:-vendor/bundle}" spec/test_all.rb
 else
   bundle exec ruby spec/test_all.rb
 fi

--- a/bin/test_all.sh
+++ b/bin/test_all.sh
@@ -2,8 +2,7 @@
 
 HAS_JRUBY=$(ruby -v | grep -o jruby)
 if [[ $HAS_JRUBY = "jruby"  ]]; then
-  echo "Using ${BUNDLE_PATH:-vendor/bundle} for an include path"
-  JRUBY_OPTS="--debug" jruby -I "${BUNDLE_PATH:-vendor/bundle}" spec/test_all.rb
+  JRUBY_OPTS="--debug" BUNDLE_PATH=./vendor/bundle bundle exec jruby spec/test_all.rb
 else
   bundle exec ruby spec/test_all.rb
 fi

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -1,6 +1,7 @@
 require_relative "spec_helper"
 
 describe Retriable::Config do
+  include Minitest::Spec::DSL
   subject do
     Retriable::Config
   end

--- a/spec/exponential_backoff_spec.rb
+++ b/spec/exponential_backoff_spec.rb
@@ -1,6 +1,7 @@
 require_relative "spec_helper"
 
 describe Retriable::ExponentialBackoff do
+  include Minitest::Spec::DSL
   subject do
     Retriable::ExponentialBackoff
   end

--- a/spec/retriable_spec.rb
+++ b/spec/retriable_spec.rb
@@ -3,6 +3,7 @@ require_relative "spec_helper"
 class TestError < Exception; end
 
 describe Retriable do
+  include Minitest::Spec::DSL
   subject do
     Retriable
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,5 @@
-require "codeclimate-test-reporter"
 require "simplecov"
+require "codeclimate-test-reporter"
 
 CodeClimate::TestReporter.configure do |config|
   config.logger.level = Logger::WARN
@@ -8,6 +8,7 @@ end
 SimpleCov.start
 
 require "minitest/autorun"
+require "minitest/spec"
 require "minitest/focus"
 require "pry"
 

--- a/spec/test_all.rb
+++ b/spec/test_all.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require_relative "spec_helper"
 require_relative "config_spec"
 require_relative "exponential_backoff_spec"
 require_relative "retriable_spec"

--- a/spec/test_all.rb
+++ b/spec/test_all.rb
@@ -1,0 +1,4 @@
+require_relative "config_spec"
+require_relative "exponential_backoff_spec"
+require_relative "retriable_spec"
+

--- a/spec/test_all.rb
+++ b/spec/test_all.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "config_spec"
 require_relative "exponential_backoff_spec"
 require_relative "retriable_spec"


### PR DESCRIPTION
This PR tries to make minitest runs work correctly on JRuby.

- use built-in minitest, calling `ruby` directly
- require relative each of the tests in `spec/test_all.rb`
- include the DSL in each of the tests
- require the minitest/spec in the helper

All of this makes the tests pass!

That made me take away ruby-head and jruby-head from the allow_failures.

**Update**: I can't get MiniTest to do the right thing here. The commits list shows my tragic path.