### PR TITLE
Travis: jruby-9.2.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ rvm:
   - 2.4.2
   - ruby-head
   - jruby-9.0.5.0
-  - jruby-9.1.15.0
+  - jruby-9.1.17.0
   - jruby-head
   - rbx-3.86
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ rvm:
   - 2.4.2
   - ruby-head
   - jruby-9.0.5.0
-  - jruby-9.1.17.0
+  - jruby-9.2.0.0
   - jruby-head
   - rbx-3.86
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ rvm:
   - 2.3.5
   - 2.4.2
   - ruby-head
-  - jruby-9.0.5.0
   - jruby-9.2.0.0
   - jruby-head
   - rbx-3.86


### PR DESCRIPTION
This PR updates the CI matrix to use latest JRuby.

http://jruby.org/2018/05/24/jruby-9-2-0-0.html