### PR TITLE
Travis: add latest Ruby, JRuby

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,9 @@ rvm:
   - 2.3.7
   - 2.4.4
   - 2.5.1
+  - 2.6.0
   - ruby-head
-  - jruby-9.2.0.0
+  - jruby-9.2.5.0
   - jruby-head
   - rbx-3.99
 script:


### PR DESCRIPTION
This PR updates the CI matrix to use latest JRuby, 9.2.5.0.

Also adds Ruby 2.6.0.

[JRuby 9.2.5.0 release blog post](https://www.jruby.org/2018/12/06/jruby-9-2-5-0.html)