### PR TITLE
Use rubygems < v3 which supports ruby < 2.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,8 +23,8 @@ matrix:
     - rvm: rbx-3.99
 
 before_install:
-  - gem install rubygems-update -v '<3' && update_rubygems
-  - gem install bundler
+  - gem install rubygems-update -v '<3' --no-document && update_rubygems
+  - gem install bundler -v 1.17.3
 
 addons:
   code_climate:

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ matrix:
     - rvm: rbx-3.99
 
 before_install:
-  - gem update --system
+  - gem install rubygems-update -v '<3' && update_rubygems
   - gem install bundler
 
 addons:


### PR DESCRIPTION
Fixes #74 

Applying the fix proposed https://github.com/rubygems/rubygems/issues/2534#issuecomment-448912364 / https://github.com/colszowka/simplecov/commit/ba423820d1d1164fcc038e7b6163b8a96d1786be

Also when I uses `rubygems` < 3, bundler then failed to install b/c the latest bundler required a newer version of ruby. The suggestion on the build said to use `bundler` `1.17.3

Open to other suggestions here 😄 