### PR TITLE
CI: 2.5.5, 2.6.2, drop unused option

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 # Send builds to container-based infrastructure
 # http://docs.travis-ci.com/user/workers/container-based-infrastructure/
 dist: trusty
-sudo: false
 language: ruby
 rvm:
   - 2.0.0
@@ -9,10 +8,10 @@ rvm:
   - 2.2.10
   - 2.3.7
   - 2.4.4
-  - 2.5.1
-  - 2.6.0
+  - 2.5.5
+  - 2.6.2
   - ruby-head
-  - jruby-9.2.5.0
+  - jruby-9.2.6.0
   - jruby-head
   - rbx-3.99
 script:


### PR DESCRIPTION
This PR updates the CI matrix to latest Ruby releases.

Also: drops an unused Travis option.