### PR TITLE
CI: Use jruby-9.2.8.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ rvm:
   - 2.5.5
   - 2.6.2
   - ruby-head
-  - jruby-9.2.7.0
+  - jruby-9.2.8.0
   - jruby-head
   - rbx-3.99
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ rvm:
   - 2.5.5
   - 2.6.2
   - ruby-head
-  - jruby-9.2.8.0
+  - jruby-9.2.9.0
   - jruby-head
   - rbx-3.99
 script:


### PR DESCRIPTION
This PR updates the CI matrix to use latest JRuby, **9.2.8.0**.

[JRuby 9.2.8.0 release blog post](https://www.jruby.org/2019/08/12/jruby-9-2-8-0.html)