### PR TITLE
Replace deprecated "codeclimate-test-reporter" gem by their unified test reporter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,17 +14,26 @@ rvm:
   - jruby-9.2.7.0
   - jruby-head
   - rbx-3.99
-script:
-  - bundle exec rspec
 
 matrix:
   allow_failures:
     - rvm: rbx-3.99
 
+env:
+  global:
+    - CC_TEST_REPORTER_ID=20a1139ef1830b4f813a10a03d90e8aa179b5226f75e75c5a949b25756ebf558
+
 before_install:
   - gem install rubygems-update -v '<3' --no-document && update_rubygems
   - gem install bundler -v 1.17.3
 
-addons:
-  code_climate:
-    repo_token: 20a1139ef1830b4f813a10a03d90e8aa179b5226f75e75c5a949b25756ebf558
+before_script:
+  - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
+  - chmod +x ./cc-test-reporter
+  - ./cc-test-reporter before-build
+
+script:
+  - bundle exec rspec
+
+after_script:
+  - ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT

--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,6 @@ source "https://rubygems.org"
 gemspec
 
 group :test do
-  gem "codeclimate-test-reporter", require: false
   gem "rspec"
   gem "simplecov", require: false
 end

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://secure.travis-ci.org/kamui/retriable.svg)](http://travis-ci.org/kamui/retriable)
 [![Code Climate](https://codeclimate.com/github/kamui/retriable/badges/gpa.svg)](https://codeclimate.com/github/kamui/retriable)
-[![Test Coverage](https://codeclimate.com/github/kamui/retriable/badges/coverage.svg)](https://codeclimate.com/github/kamui/retriable)
+[![Test Coverage](https://codeclimate.com/github/kamui/retriable/badges/coverage.svg)](https://codeclimate.com/github/kamui/retriable/coverage)
 [![Reviewed by Hound](https://img.shields.io/badge/Reviewed_by-Hound-8E64B0.svg)](https://houndci.com)
 
 Retriable is a simple DSL to retry failed code blocks with randomized [exponential backoff](http://en.wikipedia.org/wiki/Exponential_backoff) time intervals. This is especially useful when interacting external APIs, remote services, or file system calls.

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,10 +1,4 @@
-require "codeclimate-test-reporter"
 require "simplecov"
-
-CodeClimate::TestReporter.configure do |config|
-  config.logger.level = Logger::WARN
-end
-
 SimpleCov.start
 
 require "pry"


### PR DESCRIPTION
Here is a deprecation
```
Using pry 0.12.2
Using rainbow 3.0.0
Using retriable 3.1.2 from source at `.`
Using rspec-support 3.8.2
Using rspec-core 3.8.2
Using rspec-expectations 3.8.4
Using rspec-mocks 3.8.1
Using rspec 3.8.0
Using ruby-progressbar 1.10.1
Fetching unicode-display_width 1.6.0
Installing unicode-display_width 1.6.0
Fetching rubocop 0.74.0
Installing rubocop 0.74.0
Bundle complete! 8 Gemfile dependencies, 29 gems now installed.
Use `bundle info [gemname]` to see where a bundled gem is installed.
Post-install message from codeclimate-test-reporter:

  Code Climate's codeclimate-test-reporter gem has been deprecated in favor of
  our language-agnostic unified test reporter. The new test reporter is faster,
  distributed as a static binary so dependency conflicts never occur, and
  supports parallelized CI builds & multi-language CI configurations.

  Please visit https://docs.codeclimate.com/v1.0/docs/configuring-test-coverage
  for help setting up your CI process with our new test reporter.
```

And this will fix currently nonworking readme's link to test coverage.