### PR TITLE
Allow to enable/disable Retriable globally

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,64 +308,17 @@ end
 
 When you are running tests for your app it often takes a long time to retry blocks that fail. This is because Retriable will default to 3 tries with exponential backoff. Ideally your tests will run as quickly as possible.
 
-You can disable retrying by setting `tries` to 1 in the test environment. If you want to test that the code is retrying an error, you want to [turn off exponential backoff](#turn-off-exponential-backoff).
-
-Under Rails, you could change your initializer to have different options in test, as follows:
-
+You can disable retrying in the test environment:
 ```ruby
-# config/initializers/retriable.rb
-Retriable.configure do |c|
-  # ... default configuration
+Retriable.enabled?
+=> true
 
-  if Rails.env.test?
-    c.tries = 1
-  end
-end
+Retriable.disable
+
+Retriable.enabled?
+=> false
 ```
-
-Alternately, if you are using RSpec, you could override the Retriable confguration in your `spec_helper`.
-
-```ruby
-# spec/spec_helper.rb
-Retriable.configure do |c|
-  c.tries = 1
-end
-```
-
-If you have defined contexts for your configuration, you'll need to change values for each context, because those values take precedence over the default configured value.
-
-For example assuming you have configured a `google_api` context:
-```ruby
-# config/initializers/retriable.rb
-Retriable.configure do |c|
-  c.contexts[:google_api] = {
-      tries:         5,
-      base_interval: 3,
-      on:            [
-          Net::ReadTimeout,
-          Signet::AuthorizationError,
-          Errno::ECONNRESET,
-          OpenSSL::SSL::SSLError
-      ]
-  }
-end
-```
-
-Then in your test environment, you would need to set each context and the default value:
-
-```ruby
-# spec/spec_helper.rb
-Retriable.configure do |c|
-  c.multiplier    = 1.0
-  c.rand_factor   = 0.0
-  c.base_interval = 0
-
-  c.contexts.keys.each do |context|
-    c.contexts[context][:tries]         = 1
-    c.contexts[context][:base_interval] = 0
-  end
-end
-```
+If you want to test that the code is retrying an error, you want to [turn off exponential backoff](#turn-off-exponential-backoff).
 
 ## Proxy Wrapper Object
 

--- a/lib/retriable.rb
+++ b/lib/retriable.rb
@@ -14,6 +14,18 @@ module Retriable
     @config ||= Config.new
   end
 
+  def enable
+    @enabled = true
+  end
+
+  def enabled?
+    @enabled != false
+  end
+
+  def disable
+    @enabled = false
+  end
+
   def with_context(context_key, options = {}, &block)
     if !config.contexts.key?(context_key)
       raise ArgumentError, "#{context_key} not found in Retriable.config.contexts. Available contexts: #{config.contexts.keys}"
@@ -59,7 +71,9 @@ module Retriable
       begin
         return Timeout.timeout(timeout) { return yield(try) } if timeout
         return yield(try)
-      rescue *[*exception_list] => exception
+      rescue *exception_list => exception
+        raise unless enabled?
+
         if on.is_a?(Hash)
           raise unless exception_list.any? do |e|
             exception.is_a?(e) && ([*on[e]].empty? || [*on[e]].any? { |pattern| exception.message =~ pattern })

--- a/spec/retriable_spec.rb
+++ b/spec/retriable_spec.rb
@@ -222,6 +222,17 @@ describe Retriable do
     it "raises ArgumentError on invalid options" do
       expect { described_class.retriable(does_not_exist: 123) { increment_tries } }.to raise_error(ArgumentError)
     end
+
+    it "raises without retries when disabled" do
+      begin
+        described_class.disable
+        expect(described_class.enabled?).to be_falsey
+        expect { described_class.retriable(tries: 10) { increment_tries_with_exception } }.to raise_error(StandardError)
+        expect(@tries).to eq(1)
+      ensure
+        described_class.enable
+      end
+    end
   end
 
   context "#configure" do
@@ -261,5 +272,9 @@ describe Retriable do
     it "raises an ArgumentError when the context isn't found" do
       expect { described_class.with_context(:wtf) { increment_tries } }.to raise_error(ArgumentError, /wtf not found/)
     end
+  end
+
+  it "is enabled by default" do
+    expect(described_class.enabled?).to be_truthy
   end
 end


### PR DESCRIPTION
This is primarily for testing convenience, but can be very useful in development, for example, when you want to quickly disable/reenable retrying.