### PR TITLE
CI: Use JRuby 9.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ rvm:
   - 2.5.5
   - 2.6.2
   - ruby-head
-  - jruby-9.2.9.0
+  - jruby-9.2.15.0
   - jruby-head
   - rbx-3.99
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ rvm:
   - 2.5.5
   - 2.6.2
   - ruby-head
-  - jruby-9.2.15.0
+  - jruby-9.2.16.0
   - jruby-head
   - rbx-3.99
 


### PR DESCRIPTION
This PR updates the CI matrix to use latest JRuby, **9.2.16.0**.

[JRuby 9.2.16.0 release blog post](https://www.jruby.org/2021/03/03/jruby-9-2-16-0.html)