### PR TITLE
CI: Use JRuby 9.2.18.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ rvm:
   - 2.7
   - 3.0
   - ruby-head
-  - jruby-9.2.16.0
+  - jruby-9.2.18.0
   - truffleruby-head
 
 matrix:


### PR DESCRIPTION
This PR updates the CI matrix to use latest JRuby, **9.2.18.0**.

[JRuby 9.2.18.0 release blog post](https://www.jruby.org/2021/06/08/jruby-9-2-18-0.html)