### PR TITLE
Add opt-in infinite retries with elapsed-time guard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 ## 3.4.0
 
 - Add `retry_if` option to support custom retry predicates, including checks against wrapped `exception.cause` values.
+- Add opt-in infinite retries via `tries: :infinite`, requiring a finite `max_elapsed_time` safety bound.
 
 ## 3.3.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 3.6.1
 
+- Add opt-in infinite retries via `tries: :infinite`, requiring a finite `max_elapsed_time` safety bound.
 - Fix: Validate the `on:` option before retrying. Previously, passing a non-`Exception` value such as `Object`, `Kernel`, or a plain `Module` (which appear in every `Exception`'s ancestor chain) would silently retry process-critical exceptions like `SystemExit` and `Interrupt`. The `on:` option now requires an `Exception` subclass, an array of them, or a hash whose keys are such classes and whose values are `nil`, a `Regexp`, or an array of `Regexp`s. Invalid shapes raise `ArgumentError` before the block runs.
 - Fix: Validate `with_override(contexts:)` shape before applying overrides. `contexts` may be `nil` or a hash, and each per-context override must be a hash.
 - Docs: Document that `on_retry: false` disables a callback set in `Retriable.configure` for a single call.
@@ -28,7 +29,6 @@
 ## 3.4.0
 
 - Add `retry_if` option to support custom retry predicates, including checks against wrapped `exception.cause` values.
-- Add opt-in infinite retries via `tries: :infinite`, requiring a finite `max_elapsed_time` safety bound.
 
 ## 3.3.0
 

--- a/README.md
+++ b/README.md
@@ -285,6 +285,7 @@ end
 
 `max_elapsed_time` must be a finite number when using `tries: :infinite`.
 Retriable raises `ArgumentError` if `max_elapsed_time` is unbounded.
+If you provide custom `intervals` with infinite retries, Retriable uses each interval once and then repeats the last interval until the block succeeds or `max_elapsed_time` is reached.
 
 ### Turn off Exponential Backoff
 

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ Here are the available options, in some vague order of relevance to most common 
 
 | Option                 | Default           | Definition                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
 | ---------------------- | ----------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **`tries`**            | `3`               | Number of attempts to make at running your code block (includes initial attempt).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
+| **`tries`**            | `3`               | Number of attempts to make at running your code block (includes initial attempt). Pass `:infinite` to keep retrying until success or until `max_elapsed_time` is reached.                                                                                                                                                                                                                                                                                                                                                                                                                                            |
 | **`on`**               | `[StandardError]` | Type of exceptions to retry. [Read more](#configuring-which-options-to-retry-with-on).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
 | **`retry_if`**         | `nil`             | Callable (for example a `Proc` or lambda) that receives the rescued exception and returns true/false to decide whether to retry. [Read more](#advanced-retry-matching-with-retry_if).                                                                                                                                                                                                                                                                                                                                                                                                                                 |
 | **`on_retry`**         | `nil`             | `Proc` to call after each try is rescued. Pass `false` to disable a callback set in `#configure` for a single call. [Read more](#callbacks).                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
@@ -272,6 +272,19 @@ end
 ```
 
 This example makes 5 total attempts. If the first attempt fails, the 2nd attempt occurs 0.5 seconds later.
+
+### Infinite Retries (Opt-in)
+
+You can opt in to infinite retries with `tries: :infinite`. This is useful for long-running worker processes where retrying should continue until success, but it should be used carefully.
+
+```ruby
+Retriable.retriable(tries: :infinite, max_elapsed_time: 300) do
+  # code here...
+end
+```
+
+`max_elapsed_time` must be a finite number when using `tries: :infinite`.
+Retriable raises `ArgumentError` if `max_elapsed_time` is unbounded.
 
 ### Turn off Exponential Backoff
 

--- a/lib/retriable.rb
+++ b/lib/retriable.rb
@@ -13,6 +13,9 @@ module Retriable
   # break callers that use fiber-based concurrency.
   OVERRIDE_THREAD_KEY = :retriable_override
 
+  RetryPlan = Struct.new(:max_tries, :interval_for, keyword_init: true)
+  private_constant :RetryPlan
+
   module_function
 
   def configure
@@ -67,7 +70,7 @@ module Retriable
     on_retry = local_config.on_retry
     sleep_disabled = local_config.sleep_disabled
     max_elapsed_time = local_config.max_elapsed_time
-    max_tries, interval_for = retry_plan(local_config)
+    plan = retry_plan(local_config)
 
     exception_list = on.is_a?(Hash) ? on.keys : on
     exception_list = [*exception_list]
@@ -75,7 +78,7 @@ module Retriable
     elapsed_time = -> { Process.clock_gettime(Process::CLOCK_MONOTONIC) - start_time }
 
     execute_tries(
-      max_tries: max_tries, interval_for: interval_for, timeout: timeout,
+      max_tries: plan.max_tries, interval_for: plan.interval_for, timeout: timeout,
       exception_list: exception_list, on: on, retry_if: retry_if, on_retry: on_retry,
       elapsed_time: elapsed_time, max_elapsed_time: max_elapsed_time,
       sleep_disabled: sleep_disabled, &block
@@ -105,11 +108,28 @@ module Retriable
     end
   end
 
-  def build_intervals(local_config, tries)
+  def retry_plan(local_config)
+    return infinite_retry_plan(local_config) if local_config.tries == :infinite
+
+    intervals = finite_intervals(local_config)
+    RetryPlan.new(max_tries: intervals.size + 1, interval_for: ->(i) { intervals[i] })
+  end
+
+  def infinite_retry_plan(local_config)
+    unless Config.finite_number?(local_config.max_elapsed_time)
+      raise ArgumentError,
+            "max_elapsed_time must be finite when tries is :infinite"
+    end
+    raise ArgumentError, "intervals must not be empty for infinite retries" if local_config.intervals == []
+
+    RetryPlan.new(max_tries: nil, interval_for: infinite_interval_provider(local_config))
+  end
+
+  def finite_intervals(local_config)
     return local_config.intervals if local_config.intervals
 
     ExponentialBackoff.new(
-      tries: tries - 1,
+      tries: local_config.tries - 1,
       base_interval: local_config.base_interval,
       multiplier: local_config.multiplier,
       max_interval: local_config.max_interval,
@@ -117,26 +137,8 @@ module Retriable
     ).intervals
   end
 
-  def retry_plan(local_config)
-    return infinite_retry_plan(local_config) if local_config.tries == :infinite
-
-    intervals = build_intervals(local_config, local_config.tries)
-    [intervals.size + 1, ->(i) { intervals[i] }]
-  end
-
-  def infinite_retry_plan(local_config)
-    unless finite_number?(local_config.max_elapsed_time)
-      raise ArgumentError,
-            "max_elapsed_time must be finite when tries is :infinite"
-    end
-
-    [nil, infinite_interval_provider(local_config)]
-  end
-
   def infinite_interval_provider(local_config)
     if local_config.intervals
-      raise ArgumentError, "intervals must not be empty for infinite retries" if local_config.intervals.empty?
-
       custom = local_config.intervals
       return ->(i) { custom.fetch(i) { custom.last } }
     end
@@ -166,10 +168,6 @@ module Retriable
     return true if max_elapsed_time.nil?
 
     (elapsed_time + interval) <= max_elapsed_time
-  end
-
-  def finite_number?(value)
-    value.is_a?(Numeric) && (!value.respond_to?(:finite?) || value.finite?)
   end
 
   # When `on` is a Hash, we need to verify the exception matches a pattern.
@@ -263,14 +261,13 @@ module Retriable
     :validate_override_options,
     :validate_context_override_options,
     :execute_tries,
-    :build_intervals,
     :retry_plan,
     :infinite_retry_plan,
+    :finite_intervals,
     :infinite_interval_provider,
     :call_with_timeout,
     :call_on_retry,
     :can_retry?,
-    :finite_number?,
     :retriable_exception?,
     :hash_exception_match?,
     :apply_override_options,

--- a/lib/retriable.rb
+++ b/lib/retriable.rb
@@ -63,7 +63,6 @@ module Retriable
     local_config.validate!
 
     tries = local_config.tries
-    intervals = build_intervals(local_config, tries)
     timeout = local_config.timeout
     on = local_config.on
     retry_if = local_config.retry_if
@@ -71,15 +70,38 @@ module Retriable
     sleep_disabled = local_config.sleep_disabled
     max_elapsed_time = local_config.max_elapsed_time
 
+    if tries == :infinite
+      unless finite_number?(max_elapsed_time)
+        raise ArgumentError,
+              "max_elapsed_time must be finite when tries is :infinite"
+      end
+
+      if local_config.intervals
+        raise ArgumentError, "intervals must not be empty for infinite retries" if local_config.intervals.empty?
+
+        custom = local_config.intervals
+        interval_for = ->(i) { custom[[i, custom.size - 1].min] }
+      else
+        backoff = ExponentialBackoff.new(
+          base_interval: local_config.base_interval, multiplier: local_config.multiplier,
+          max_interval: local_config.max_interval, rand_factor: local_config.rand_factor
+        )
+        interval_for = ->(i) { backoff.interval_for(i) }
+      end
+      max_tries = nil
+    else
+      intervals = build_intervals(local_config, tries)
+      max_tries = intervals.size + 1
+      interval_for = ->(i) { intervals[i] }
+    end
+
     exception_list = on.is_a?(Hash) ? on.keys : on
     exception_list = [*exception_list]
     start_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
     elapsed_time = -> { Process.clock_gettime(Process::CLOCK_MONOTONIC) - start_time }
 
-    tries = intervals.size + 1
-
     execute_tries(
-      tries: tries, intervals: intervals, timeout: timeout,
+      max_tries: max_tries, interval_for: interval_for, timeout: timeout,
       exception_list: exception_list, on: on, retry_if: retry_if, on_retry: on_retry,
       elapsed_time: elapsed_time, max_elapsed_time: max_elapsed_time,
       sleep_disabled: sleep_disabled, &block
@@ -87,22 +109,22 @@ module Retriable
   end
 
   def execute_tries( # rubocop:disable Metrics/ParameterLists
-    tries:, intervals:, timeout:, exception_list:,
+    max_tries:, interval_for:, timeout:, exception_list:,
     on:, retry_if:, on_retry:, elapsed_time:, max_elapsed_time:, sleep_disabled:, &block
   )
-    tries.times do |index|
-      try = index + 1
-
+    try = 0
+    loop do
+      try += 1
       begin
         return call_with_timeout(timeout, try, &block)
       rescue *exception_list => e
         raise unless retriable_exception?(e, on, exception_list, retry_if)
 
-        interval = intervals[index]
+        interval = interval_for.call(try - 1)
         call_on_retry(on_retry, e, try, elapsed_time.call, interval)
 
         elapsed_interval = sleep_disabled == true ? 0 : interval
-        raise unless can_retry?(try, tries, elapsed_time.call, elapsed_interval, max_elapsed_time)
+        raise unless can_retry?(try, max_tries, elapsed_time.call, elapsed_interval, max_elapsed_time)
 
         sleep interval if sleep_disabled != true
       end
@@ -133,11 +155,15 @@ module Retriable
     on_retry.call(exception, try, elapsed_time, interval)
   end
 
-  def can_retry?(try, tries, elapsed_time, interval, max_elapsed_time)
-    return false unless try < tries
+  def can_retry?(try, max_tries, elapsed_time, interval, max_elapsed_time)
+    return false if max_tries && try >= max_tries
     return true if max_elapsed_time.nil?
 
     (elapsed_time + interval) <= max_elapsed_time
+  end
+
+  def finite_number?(value)
+    value.is_a?(Numeric) && (!value.respond_to?(:finite?) || value.finite?)
   end
 
   # When `on` is a Hash, we need to verify the exception matches a pattern.
@@ -235,6 +261,7 @@ module Retriable
     :call_with_timeout,
     :call_on_retry,
     :can_retry?,
+    :finite_number?,
     :retriable_exception?,
     :hash_exception_match?,
     :apply_override_options,

--- a/lib/retriable.rb
+++ b/lib/retriable.rb
@@ -61,39 +61,13 @@ module Retriable
 
     # Config is mutable through `configure`, so validate again immediately before use.
     local_config.validate!
-
-    tries = local_config.tries
     timeout = local_config.timeout
     on = local_config.on
     retry_if = local_config.retry_if
     on_retry = local_config.on_retry
     sleep_disabled = local_config.sleep_disabled
     max_elapsed_time = local_config.max_elapsed_time
-
-    if tries == :infinite
-      unless finite_number?(max_elapsed_time)
-        raise ArgumentError,
-              "max_elapsed_time must be finite when tries is :infinite"
-      end
-
-      if local_config.intervals
-        raise ArgumentError, "intervals must not be empty for infinite retries" if local_config.intervals.empty?
-
-        custom = local_config.intervals
-        interval_for = ->(i) { custom[[i, custom.size - 1].min] }
-      else
-        backoff = ExponentialBackoff.new(
-          base_interval: local_config.base_interval, multiplier: local_config.multiplier,
-          max_interval: local_config.max_interval, rand_factor: local_config.rand_factor
-        )
-        interval_for = ->(i) { backoff.interval_for(i) }
-      end
-      max_tries = nil
-    else
-      intervals = build_intervals(local_config, tries)
-      max_tries = intervals.size + 1
-      interval_for = ->(i) { intervals[i] }
-    end
+    max_tries, interval_for = retry_plan(local_config)
 
     exception_list = on.is_a?(Hash) ? on.keys : on
     exception_list = [*exception_list]
@@ -141,6 +115,38 @@ module Retriable
       max_interval: local_config.max_interval,
       rand_factor: local_config.rand_factor,
     ).intervals
+  end
+
+  def retry_plan(local_config)
+    return infinite_retry_plan(local_config) if local_config.tries == :infinite
+
+    intervals = build_intervals(local_config, local_config.tries)
+    [intervals.size + 1, ->(i) { intervals[i] }]
+  end
+
+  def infinite_retry_plan(local_config)
+    unless finite_number?(local_config.max_elapsed_time)
+      raise ArgumentError,
+            "max_elapsed_time must be finite when tries is :infinite"
+    end
+
+    [nil, infinite_interval_provider(local_config)]
+  end
+
+  def infinite_interval_provider(local_config)
+    if local_config.intervals
+      raise ArgumentError, "intervals must not be empty for infinite retries" if local_config.intervals.empty?
+
+      custom = local_config.intervals
+      return ->(i) { custom.fetch(i) { custom.last } }
+    end
+
+    ExponentialBackoff.new(
+      base_interval: local_config.base_interval,
+      multiplier: local_config.multiplier,
+      max_interval: local_config.max_interval,
+      rand_factor: local_config.rand_factor,
+    ).interval_provider
   end
 
   def call_with_timeout(timeout, try)
@@ -258,6 +264,9 @@ module Retriable
     :validate_context_override_options,
     :execute_tries,
     :build_intervals,
+    :retry_plan,
+    :infinite_retry_plan,
+    :infinite_interval_provider,
     :call_with_timeout,
     :call_on_retry,
     :can_retry?,

--- a/lib/retriable.rb
+++ b/lib/retriable.rb
@@ -13,7 +13,7 @@ module Retriable
   # break callers that use fiber-based concurrency.
   OVERRIDE_THREAD_KEY = :retriable_override
 
-  RetryPlan = Struct.new(:max_tries, :interval_for, keyword_init: true)
+  RetryPlan = Struct.new(:max_tries, :interval_for)
   private_constant :RetryPlan
 
   module_function
@@ -112,7 +112,7 @@ module Retriable
     return infinite_retry_plan(local_config) if local_config.tries == :infinite
 
     intervals = finite_intervals(local_config)
-    RetryPlan.new(max_tries: intervals.size + 1, interval_for: ->(i) { intervals[i] })
+    RetryPlan.new(intervals.size + 1, ->(i) { intervals[i] })
   end
 
   def infinite_retry_plan(local_config)
@@ -122,7 +122,7 @@ module Retriable
     end
     raise ArgumentError, "intervals must not be empty for infinite retries" if local_config.intervals == []
 
-    RetryPlan.new(max_tries: nil, interval_for: infinite_interval_provider(local_config))
+    RetryPlan.new(nil, infinite_interval_provider(local_config))
   end
 
   def finite_intervals(local_config)

--- a/lib/retriable/config.rb
+++ b/lib/retriable/config.rb
@@ -20,6 +20,10 @@ module Retriable
 
     attr_accessor(*ATTRIBUTES)
 
+    def self.finite_number?(value)
+      value.is_a?(Numeric) && value.to_f.finite?
+    end
+
     def initialize(opts = {})
       backoff = ExponentialBackoff.new
 
@@ -57,6 +61,7 @@ module Retriable
       validate_optional_non_negative_number(:timeout, timeout)
       validate_on(on)
       validate_intervals
+      validate_infinite_max_elapsed_time if tries == :infinite
       return if intervals
       return validate_backoff_options if tries == :infinite
 
@@ -79,6 +84,12 @@ module Retriable
       return if intervals.all? { |interval| finite_number?(interval) && interval >= 0 }
 
       raise ArgumentError, "intervals must contain only non-negative numbers"
+    end
+
+    def validate_infinite_max_elapsed_time
+      return if finite_number?(max_elapsed_time)
+
+      raise ArgumentError, "max_elapsed_time must be finite when tries is :infinite"
     end
   end
 end

--- a/lib/retriable/config.rb
+++ b/lib/retriable/config.rb
@@ -58,8 +58,13 @@ module Retriable
       validate_on(on)
       validate_intervals
       return if intervals
+      return validate_backoff_options if tries == :infinite
 
       validate_positive_integer(:tries, tries)
+      validate_backoff_options
+    end
+
+    def validate_backoff_options
       validate_non_negative_number(:base_interval, base_interval)
       validate_non_negative_number(:multiplier, multiplier)
       validate_non_negative_number(:max_interval, max_interval)

--- a/lib/retriable/exponential_backoff.rb
+++ b/lib/retriable/exponential_backoff.rb
@@ -43,6 +43,17 @@ module Retriable
       randomize(interval)
     end
 
+    def interval_provider
+      raw_interval = base_interval
+
+      lambda do |_iteration|
+        interval = [raw_interval, max_interval].min
+        raw_interval = next_raw_interval(raw_interval)
+
+        rand_factor.zero? ? interval : randomize(interval)
+      end
+    end
+
     private
 
     def validate!
@@ -51,6 +62,12 @@ module Retriable
       validate_non_negative_number(:multiplier, multiplier)
       validate_non_negative_number(:max_interval, max_interval)
       validate_rand_factor
+    end
+
+    def next_raw_interval(raw_interval)
+      return max_interval if multiplier >= 1 && raw_interval >= max_interval
+
+      raw_interval * multiplier
     end
 
     def randomize(interval)

--- a/lib/retriable/exponential_backoff.rb
+++ b/lib/retriable/exponential_backoff.rb
@@ -33,13 +33,14 @@ module Retriable
     end
 
     def intervals
-      intervals = Array.new(tries) do |iteration|
-        [base_interval * (multiplier**iteration), max_interval].min
-      end
+      Array.new(tries) { |iteration| interval_for(iteration) }
+    end
 
-      return intervals if rand_factor.zero?
+    def interval_for(iteration)
+      interval = [base_interval * (multiplier**iteration), max_interval].min
+      return interval if rand_factor.zero?
 
-      intervals.map { |i| randomize(i) }
+      randomize(interval)
     end
 
     private

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -131,4 +131,9 @@ describe Retriable::Config do
         .to raise_error(ArgumentError, /on must be an Exception class/)
     end
   end
+
+  it "requires max_elapsed_time when tries is infinite" do
+    expect { described_class.new(tries: :infinite, max_elapsed_time: nil) }
+      .to raise_error(ArgumentError, /max_elapsed_time/)
+  end
 end

--- a/spec/exponential_backoff_spec.rb
+++ b/spec/exponential_backoff_spec.rb
@@ -71,4 +71,11 @@ describe Retriable::ExponentialBackoff do
     non_random_intervals = 9.times.inject([0.5]) { |memo, _i| memo + [memo.last * 1.5] }
     expect(described_class.new(tries: 10, rand_factor: 0.0).intervals).to eq(non_random_intervals)
   end
+
+  it "provides capped intervals lazily" do
+    interval_for = described_class.new(base_interval: 1.0, multiplier: 2.0, max_interval: 4.0, rand_factor: 0.0)
+                                  .interval_provider
+
+    expect(5.times.map { |index| interval_for.call(index) }).to eq([1.0, 2.0, 4.0, 4.0, 4.0])
+  end
 end

--- a/spec/exponential_backoff_spec.rb
+++ b/spec/exponential_backoff_spec.rb
@@ -22,17 +22,19 @@ describe Retriable::ExponentialBackoff do
   end
 
   it "generates 10 randomized intervals" do
-    expect(described_class.new(tries: 9).intervals).to eq([
-                                                            0.5244067512211441,
-                                                            0.9113920238761231,
-                                                            1.2406087918999114,
-                                                            1.7632403621664823,
-                                                            2.338001204738311,
-                                                            4.350816718580626,
-                                                            5.339852157217869,
-                                                            11.889873261212443,
-                                                            18.756037881636484,
-                                                          ])
+    expected_intervals = [
+      0.5244067512211441,
+      0.9113920238761231,
+      1.2406087918999114,
+      1.7632403621664823,
+      2.338001204738311,
+      4.350816718580626,
+      5.339852157217869,
+      11.889873261212443,
+      18.756037881636484,
+    ]
+
+    expect(described_class.new(tries: 9).intervals).to eq(expected_intervals)
   end
 
   it "generates defined number of intervals" do
@@ -40,19 +42,23 @@ describe Retriable::ExponentialBackoff do
   end
 
   it "generates intervals with a defined base interval" do
-    expect(described_class.new(base_interval: 1).intervals).to eq([
-                                                                    1.0488135024422882,
-                                                                    1.8227840477522461,
-                                                                    2.4812175837998227,
-                                                                  ])
+    expected_intervals = [
+      1.0488135024422882,
+      1.8227840477522461,
+      2.4812175837998227,
+    ]
+
+    expect(described_class.new(base_interval: 1).intervals).to eq(expected_intervals)
   end
 
   it "generates intervals with a defined multiplier" do
-    expect(described_class.new(multiplier: 1).intervals).to eq([
-                                                                 0.5244067512211441,
-                                                                 0.607594682584082,
-                                                                 0.5513816852888495,
-                                                               ])
+    expected_intervals = [
+      0.5244067512211441,
+      0.607594682584082,
+      0.5513816852888495,
+    ]
+
+    expect(described_class.new(multiplier: 1).intervals).to eq(expected_intervals)
   end
 
   it "generates intervals with a defined max interval" do
@@ -60,11 +66,13 @@ describe Retriable::ExponentialBackoff do
   end
 
   it "generates intervals with a defined rand_factor" do
-    expect(described_class.new(rand_factor: 0.2).intervals).to eq([
-                                                                    0.5097627004884576,
-                                                                    0.8145568095504492,
-                                                                    1.1712435167599646,
-                                                                  ])
+    expected_intervals = [
+      0.5097627004884576,
+      0.8145568095504492,
+      1.1712435167599646,
+    ]
+
+    expect(described_class.new(rand_factor: 0.2).intervals).to eq(expected_intervals)
   end
 
   it "generates 10 non-randomized intervals" do

--- a/spec/exponential_backoff_spec.rb
+++ b/spec/exponential_backoff_spec.rb
@@ -23,16 +23,16 @@ describe Retriable::ExponentialBackoff do
 
   it "generates 10 randomized intervals" do
     expect(described_class.new(tries: 9).intervals).to eq([
-      0.5244067512211441,
-      0.9113920238761231,
-      1.2406087918999114,
-      1.7632403621664823,
-      2.338001204738311,
-      4.350816718580626,
-      5.339852157217869,
-      11.889873261212443,
-      18.756037881636484,
-    ])
+                                                            0.5244067512211441,
+                                                            0.9113920238761231,
+                                                            1.2406087918999114,
+                                                            1.7632403621664823,
+                                                            2.338001204738311,
+                                                            4.350816718580626,
+                                                            5.339852157217869,
+                                                            11.889873261212443,
+                                                            18.756037881636484,
+                                                          ])
   end
 
   it "generates defined number of intervals" do
@@ -41,18 +41,18 @@ describe Retriable::ExponentialBackoff do
 
   it "generates intervals with a defined base interval" do
     expect(described_class.new(base_interval: 1).intervals).to eq([
-      1.0488135024422882,
-      1.8227840477522461,
-      2.4812175837998227,
-    ])
+                                                                    1.0488135024422882,
+                                                                    1.8227840477522461,
+                                                                    2.4812175837998227,
+                                                                  ])
   end
 
   it "generates intervals with a defined multiplier" do
     expect(described_class.new(multiplier: 1).intervals).to eq([
-      0.5244067512211441,
-      0.607594682584082,
-      0.5513816852888495,
-    ])
+                                                                 0.5244067512211441,
+                                                                 0.607594682584082,
+                                                                 0.5513816852888495,
+                                                               ])
   end
 
   it "generates intervals with a defined max interval" do
@@ -61,10 +61,10 @@ describe Retriable::ExponentialBackoff do
 
   it "generates intervals with a defined rand_factor" do
     expect(described_class.new(rand_factor: 0.2).intervals).to eq([
-      0.5097627004884576,
-      0.8145568095504492,
-      1.1712435167599646,
-    ])
+                                                                    0.5097627004884576,
+                                                                    0.8145568095504492,
+                                                                    1.1712435167599646,
+                                                                  ])
   end
 
   it "generates 10 non-randomized intervals" do
@@ -76,6 +76,6 @@ describe Retriable::ExponentialBackoff do
     interval_for = described_class.new(base_interval: 1.0, multiplier: 2.0, max_interval: 4.0, rand_factor: 0.0)
                                   .interval_provider
 
-    expect(5.times.map { |index| interval_for.call(index) }).to eq([1.0, 2.0, 4.0, 4.0, 4.0])
+    expect(Array.new(5) { |index| interval_for.call(index) }).to eq([1.0, 2.0, 4.0, 4.0, 4.0])
   end
 end

--- a/spec/retriable_spec.rb
+++ b/spec/retriable_spec.rb
@@ -101,6 +101,8 @@ describe Retriable do
         start_time,
         start_time + 0.01,
         start_time + 0.01,
+        start_time + 0.02,
+        start_time + 0.02,
       ]
       allow(Process).to receive(:clock_gettime).with(Process::CLOCK_MONOTONIC) { timeline.shift || timeline.last }
 
@@ -117,7 +119,7 @@ describe Retriable do
         end
       end.to raise_error(StandardError)
 
-      expect(@tries).to eq(2)
+      expect(@tries).to eq(3)
     end
 
     it "raises ArgumentError for infinite retries without a finite max_elapsed_time" do

--- a/spec/retriable_spec.rb
+++ b/spec/retriable_spec.rb
@@ -94,7 +94,7 @@ describe Retriable do
     end
 
     it "stops infinite retries at max_elapsed_time" do
-      start_time = Time.now
+      start_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
       timeline = [
         start_time,
         start_time,
@@ -102,7 +102,7 @@ describe Retriable do
         start_time + 0.01,
         start_time + 0.01,
       ]
-      allow(Time).to receive(:now) { timeline.shift || timeline.last }
+      allow(Process).to receive(:clock_gettime).with(Process::CLOCK_MONOTONIC) { timeline.shift || timeline.last }
 
       expect do
         described_class.retriable(

--- a/spec/retriable_spec.rb
+++ b/spec/retriable_spec.rb
@@ -84,6 +84,54 @@ describe Retriable do
       expect(@tries).to eq(10)
     end
 
+    it "supports infinite retries until the block succeeds" do
+      described_class.retriable(tries: :infinite) do
+        increment_tries
+        raise StandardError if @tries < 5
+      end
+
+      expect(@tries).to eq(5)
+    end
+
+    it "stops infinite retries at max_elapsed_time" do
+      start_time = Time.now
+      timeline = [
+        start_time,
+        start_time,
+        start_time,
+        start_time + 0.01,
+        start_time + 0.01,
+      ]
+      allow(Time).to receive(:now) { timeline.shift || timeline.last }
+
+      expect do
+        described_class.retriable(
+          tries: :infinite,
+          base_interval: 0.01,
+          multiplier: 1.0,
+          rand_factor: 0.0,
+          sleep_disabled: true,
+          max_elapsed_time: 0.015,
+        ) do
+          increment_tries_with_exception
+        end
+      end.to raise_error(StandardError)
+
+      expect(@tries).to eq(2)
+    end
+
+    it "raises ArgumentError for infinite retries without a finite max_elapsed_time" do
+      expect do
+        described_class.retriable(tries: :infinite, max_elapsed_time: Float::INFINITY) { increment_tries }
+      end.to raise_error(ArgumentError, /max_elapsed_time/)
+    end
+
+    it "raises ArgumentError for infinite retries with empty intervals" do
+      expect do
+        described_class.retriable(tries: :infinite, intervals: []) { increment_tries_with_exception }
+      end.to raise_error(ArgumentError, /intervals/)
+    end
+
     it "will timeout after 1 second" do
       expect { described_class.retriable(timeout: 1) { sleep(1.1) } }.to raise_error(Timeout::Error)
     end
@@ -194,6 +242,16 @@ describe Retriable do
         expect(@next_interval_table[2]).to eq(0.2)
         expect(@next_interval_table[3]).to eq(0.3)
         expect(@next_interval_table[4]).to be_nil
+      end
+
+      it "allows non-integer tries when intervals are provided" do
+        expect do
+          described_class.retriable(intervals: [0.1], tries: :ignored) do
+            increment_tries_with_exception
+          end
+        end.to raise_error(StandardError)
+
+        expect(@tries).to eq(2)
       end
     end
 


### PR DESCRIPTION
## Summary
- add opt-in infinite retry support via `tries: :infinite` without changing existing finite retry defaults
- enforce a safety guard by requiring `max_elapsed_time` to be finite when infinite retries are enabled, including config-level validation
- simplify retry interval planning and use lazy capped backoff intervals for infinite retries
- document the new option in README and the `3.6.1` CHANGELOG section, including custom interval repeat behavior

## Testing
- `bundle exec rspec`
- `bundle exec rubocop lib/retriable.rb lib/retriable/config.rb lib/retriable/exponential_backoff.rb spec/config_spec.rb spec/exponential_backoff_spec.rb spec/retriable_spec.rb`
- `git diff --check`