### PR TITLE
Add override config layer for forced retry behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # HEAD
 
-## 3.4.1
+- Add `override` and `reset_override` APIs to force retry settings over local call options when needed (for example, test short-circuiting).
 
 - Fix: Use `Process.clock_gettime(CLOCK_MONOTONIC)` for elapsed time tracking so retry timing is immune to wall-clock adjustments (NTP, manual changes).
 - Fix: Handle `max_elapsed_time: nil` gracefully instead of raising `NoMethodError`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 - Add `override` and `reset_override` APIs to force retry settings over local call options when needed (for example, test short-circuiting).
 
+## 3.4.1
+
 - Fix: Use `Process.clock_gettime(CLOCK_MONOTONIC)` for elapsed time tracking so retry timing is immune to wall-clock adjustments (NTP, manual changes).
 - Fix: Handle `max_elapsed_time: nil` gracefully instead of raising `NoMethodError`.
 - Remove dead `* 1.0` float coercion in `ExponentialBackoff#randomize`.

--- a/README.md
+++ b/README.md
@@ -394,7 +394,7 @@ Alternately, if you are using RSpec, you could override the Retriable configurat
 Retriable.override(tries: 1, base_interval: 0, rand_factor: 0)
 ```
 
-If you have defined contexts for your configuration, you'll need to change values for each context, because those values take precedence over the default configured value.
+If you have defined contexts for your configuration, top-level override values (such as `tries: 1`) already take precedence over context-specific values. However, if you need to override context-specific options (for example, clearing a context's `:intervals` array or changing its `:on` exception list), pass `:contexts` to `Retriable.override`:
 
 For example assuming you have configured a `google_api` context:
 
@@ -414,7 +414,7 @@ Retriable.configure do |c|
 end
 ```
 
-Then in your test environment, you would need to set each context and the default value:
+Then in your test environment, you can override both top-level defaults and per-context options:
 
 ```ruby
 # Build context overrides from existing configured context keys

--- a/README.md
+++ b/README.md
@@ -142,6 +142,34 @@ Retriable.configure do |c|
 end
 ```
 
+`#configure` sets defaults only. Per-call options passed to `Retriable.retriable` and
+`Retriable.with_context` still take precedence.
+
+### Override
+
+If you need to force values globally (including over per-call options), use
+`#override`:
+
+```ruby
+Retriable.override(tries: 1, base_interval: 0)
+```
+
+`#override` precedence:
+
+```
+override > local options > configure defaults
+```
+
+`#override` uses process-global state. Once set, it affects every caller and
+thread until `#reset_override` runs. Prefer setting it once at boot (or in test
+helpers), and avoid toggling it per request in multi-threaded runtimes.
+
+To clear an override:
+
+```ruby
+Retriable.reset_override
+```
+
 ### Example Usage
 
 This example will only retry on a `Timeout::Error`, retry 3 times and sleep for a full second before each try.
@@ -340,30 +368,30 @@ end
 
 When you are running tests for your app it often takes a long time to retry blocks that fail. This is because Retriable will default to 3 tries with exponential backoff. Ideally your tests will run as quickly as possible.
 
-You can disable retrying by setting `tries` to 1 in the test environment. If you want to test that the code is retrying an error, you want to [turn off exponential backoff](#turn-off-exponential-backoff).
+If you want to short-circuit retries in tests, including calls that pass local options, use `Retriable.override` and set `tries` to `1`.
 
-Under Rails, you could change your initializer to have different options in test, as follows:
+Under Rails, keep shared defaults in `Retriable.configure` and apply test-only overrides conditionally:
 
 ```ruby
 # config/initializers/retriable.rb
 Retriable.configure do |c|
-  # ... default configuration
+  c.tries = 3
+  c.base_interval = 0.5
+  c.rand_factor = 0.5
+end
 
-  if Rails.env.test?
-    c.tries = 1
-  end
+if Rails.env.test?
+  Retriable.override(tries: 1, base_interval: 0, rand_factor: 0)
 end
 ```
 
-Note: In this and the following examples, `Retriable.configure` sets a default config, it doesn't override the configuration for the `retriable` method calls. Calling `Retriable.retriable` with options will override the default configuration for that call. So if you have `tries` set to 5 in `Retriable.configure`, but then you call `Retriable.retriable(tries: 3)`, that call will use 3 tries instead of 5. The configuration is basically a default set of options that can be overridden by passing options to the `retriable` method or by using contexts.
+If you need to run a specific test with normal retry behavior, call `Retriable.reset_override` for that example and then reapply your test override afterward.
 
-Alternately, if you are using RSpec, you could override the Retriable confguration in your `spec_helper`.
+Alternately, if you are using RSpec, you could override the Retriable configuration in your `spec_helper`.
 
 ```ruby
 # spec/spec_helper.rb
-Retriable.configure do |c|
-  c.tries = 1
-end
+Retriable.override(tries: 1, base_interval: 0, rand_factor: 0)
 ```
 
 If you have defined contexts for your configuration, you'll need to change values for each context, because those values take precedence over the default configured value.
@@ -389,17 +417,18 @@ end
 Then in your test environment, you would need to set each context and the default value:
 
 ```ruby
-# spec/spec_helper.rb
-Retriable.configure do |c|
-  c.multiplier    = 1.0
-  c.rand_factor   = 0.0
-  c.base_interval = 0
-
-  c.contexts.keys.each do |context|
-    c.contexts[context][:tries]         = 1
-    c.contexts[context][:base_interval] = 0
-  end
+# Build context overrides from existing configured context keys
+context_overrides = {}
+Retriable.config.contexts.each_key do |key|
+  context_overrides[key] = { tries: 1, base_interval: 0 }
 end
+
+Retriable.override(
+  multiplier: 1.0,
+  rand_factor: 0.0,
+  base_interval: 0,
+  contexts: context_overrides,
+)
 ```
 
 ## Credits

--- a/README.md
+++ b/README.md
@@ -164,6 +164,9 @@ override > local options > configure defaults
 thread until `#reset_override` runs. Prefer setting it once at boot (or in test
 helpers), and avoid toggling it per request in multi-threaded runtimes.
 
+`#override` stores the provided options directly. Do not mutate the options hash
+or nested values after passing them to `#override`.
+
 To clear an override:
 
 ```ruby

--- a/lib/retriable.rb
+++ b/lib/retriable.rb
@@ -18,6 +18,17 @@ module Retriable
     end
   end
 
+  def deep_dup(obj)
+    case obj
+    when Hash
+      obj.each_with_object({}) { |(k, v), h| h[k] = deep_dup(v) }
+    when Array
+      obj.map { |v| deep_dup(v) }
+    else
+      obj
+    end
+  end
+
   def configure
     yield(config)
   end
@@ -30,7 +41,7 @@ module Retriable
     opts.each_key do |k|
       raise ArgumentError, "#{k} is not a valid option" unless Config::ATTRIBUTES.include?(k)
     end
-    @override_config = opts.empty? ? nil : opts
+    @override_config = opts.empty? ? nil : deep_dup(opts).freeze
   end
 
   def reset_override
@@ -178,7 +189,9 @@ module Retriable
   end
 
   def merged_context_options(contexts, context_key, options)
-    context_options = contexts[context_key].merge(options)
+    base = contexts[context_key]
+    base = {} unless base.is_a?(Hash)
+    context_options = base.merge(options)
 
     return context_options unless override_config
 
@@ -186,13 +199,14 @@ module Retriable
     return context_options unless override_contexts.is_a?(Hash)
 
     override_context_options = override_contexts[context_key]
-    return context_options unless override_context_options
+    return context_options unless override_context_options.is_a?(Hash)
 
     deep_merge(context_options, override_context_options)
   end
 
   private_class_method(
     :deep_merge,
+    :deep_dup,
     :execute_tries,
     :build_intervals,
     :call_with_timeout,

--- a/lib/retriable.rb
+++ b/lib/retriable.rb
@@ -8,6 +8,16 @@ require_relative "retriable/version"
 module Retriable
   module_function
 
+  def deep_merge(base, overrides)
+    base.merge(overrides) do |_key, base_value, override_value|
+      if base_value.is_a?(Hash) && override_value.is_a?(Hash)
+        deep_merge(base_value, override_value)
+      else
+        override_value
+      end
+    end
+  end
+
   def configure
     yield(config)
   end
@@ -16,19 +26,40 @@ module Retriable
     @config ||= Config.new
   end
 
+  def override(opts = {})
+    opts.each_key do |k|
+      raise ArgumentError, "#{k} is not a valid option" unless Config::ATTRIBUTES.include?(k)
+    end
+    @override_config = opts.empty? ? nil : opts
+  end
+
+  def reset_override
+    @override_config = nil
+  end
+
   def with_context(context_key, options = {}, &block)
-    if !config.contexts.key?(context_key)
+    contexts = merged_contexts
+
+    if !contexts.key?(context_key)
       raise ArgumentError,
-            "#{context_key} not found in Retriable.config.contexts. Available contexts: #{config.contexts.keys}"
+            "#{context_key} not found in Retriable contexts (including overrides). Available contexts: #{contexts.keys}"
     end
 
     return unless block_given?
 
-    retriable(config.contexts[context_key].merge(options), &block)
+    context_options = merged_context_options(contexts, context_key, options)
+
+    retriable(context_options, &block)
   end
 
   def retriable(opts = {}, &block)
-    local_config = opts.empty? ? config : Config.new(config.to_h.merge(opts))
+    if opts.empty? && !override_config
+      local_config = config
+    else
+      local_config_hash = config.to_h.merge(opts)
+      local_config_hash = deep_merge(local_config_hash, override_config) if override_config
+      local_config = Config.new(local_config_hash)
+    end
 
     tries = local_config.tries
     intervals = build_intervals(local_config, tries)
@@ -128,7 +159,40 @@ module Retriable
     end
   end
 
+  def override_config
+    @override_config
+  end
+
+  def merged_contexts
+    return config.contexts unless override_config&.key?(:contexts)
+
+    base_contexts = config.contexts
+    override_contexts = override_config[:contexts]
+
+    if override_contexts.is_a?(Hash)
+      return deep_merge(base_contexts.is_a?(Hash) ? base_contexts : {}, override_contexts)
+    end
+    return {} if override_contexts.nil?
+
+    base_contexts
+  end
+
+  def merged_context_options(contexts, context_key, options)
+    context_options = contexts[context_key].merge(options)
+
+    return context_options unless override_config
+
+    override_contexts = override_config[:contexts]
+    return context_options unless override_contexts.is_a?(Hash)
+
+    override_context_options = override_contexts[context_key]
+    return context_options unless override_context_options
+
+    deep_merge(context_options, override_context_options)
+  end
+
   private_class_method(
+    :deep_merge,
     :execute_tries,
     :build_intervals,
     :call_with_timeout,
@@ -136,5 +200,8 @@ module Retriable
     :can_retry?,
     :retriable_exception?,
     :hash_exception_match?,
+    :override_config,
+    :merged_contexts,
+    :merged_context_options,
   )
 end

--- a/lib/retriable.rb
+++ b/lib/retriable.rb
@@ -8,16 +8,6 @@ require_relative "retriable/version"
 module Retriable
   module_function
 
-  def deep_merge(base, overrides)
-    base.merge(overrides) do |_key, base_value, override_value|
-      if base_value.is_a?(Hash) && override_value.is_a?(Hash)
-        deep_merge(base_value, override_value)
-      else
-        override_value
-      end
-    end
-  end
-
   def deep_dup(obj)
     case obj
     when Hash
@@ -58,7 +48,7 @@ module Retriable
 
     return unless block_given?
 
-    context_options = merged_context_options(contexts, context_key, options)
+    context_options = merged_context_options(context_key, options)
 
     retriable(context_options, &block)
   end
@@ -67,8 +57,7 @@ module Retriable
     if opts.empty? && !override_config
       local_config = config
     else
-      local_config_hash = config.to_h.merge(opts)
-      local_config_hash = deep_merge(local_config_hash, override_config) if override_config
+      local_config_hash = merge_override_options(config.to_h.merge(opts))
       local_config = Config.new(local_config_hash)
     end
 
@@ -174,22 +163,33 @@ module Retriable
     @override_config
   end
 
+  def merge_override_options(options)
+    return options unless override_config
+
+    merged_options = options.merge(override_config)
+    clear_intervals_for_forced_tries(merged_options, override_config)
+  end
+
+  def clear_intervals_for_forced_tries(options, overrides)
+    options[:intervals] = nil if overrides.key?(:tries) && !overrides.key?(:intervals)
+    options
+  end
+
   def merged_contexts
     return config.contexts unless override_config&.key?(:contexts)
 
     base_contexts = config.contexts
     override_contexts = override_config[:contexts]
 
-    if override_contexts.is_a?(Hash)
-      return deep_merge(base_contexts.is_a?(Hash) ? base_contexts : {}, override_contexts)
-    end
+    return (base_contexts.is_a?(Hash) ? base_contexts : {}).merge(override_contexts) if override_contexts.is_a?(Hash)
     return {} if override_contexts.nil?
 
     base_contexts
   end
 
-  def merged_context_options(contexts, context_key, options)
-    base = contexts[context_key]
+  def merged_context_options(context_key, options)
+    base_contexts = config.contexts.is_a?(Hash) ? config.contexts : {}
+    base = base_contexts[context_key]
     base = {} unless base.is_a?(Hash)
     context_options = base.merge(options)
 
@@ -201,11 +201,10 @@ module Retriable
     override_context_options = override_contexts[context_key]
     return context_options unless override_context_options.is_a?(Hash)
 
-    deep_merge(context_options, override_context_options)
+    clear_intervals_for_forced_tries(context_options.merge(override_context_options), override_context_options)
   end
 
   private_class_method(
-    :deep_merge,
     :deep_dup,
     :execute_tries,
     :build_intervals,
@@ -215,6 +214,8 @@ module Retriable
     :retriable_exception?,
     :hash_exception_match?,
     :override_config,
+    :merge_override_options,
+    :clear_intervals_for_forced_tries,
     :merged_contexts,
     :merged_context_options,
   )

--- a/lib/retriable.rb
+++ b/lib/retriable.rb
@@ -28,10 +28,10 @@ module Retriable
   end
 
   def override(opts = {})
-    opts.each_key do |k|
-      raise ArgumentError, "#{k} is not a valid option" unless Config::ATTRIBUTES.include?(k)
-    end
-    @override_config = opts.empty? ? nil : deep_dup(opts).freeze
+    raise ArgumentError, "empty override options are not allowed; use reset_override instead" if opts.empty?
+
+    validate_override_options(opts)
+    @override_config = deep_dup(opts).freeze
   end
 
   def reset_override
@@ -54,7 +54,7 @@ module Retriable
   end
 
   def retriable(opts = {}, &block)
-    if opts.empty? && !override_config
+    if opts.empty? && !@override_config
       local_config = config
     else
       local_config_hash = merge_override_options(config.to_h.merge(opts))
@@ -159,15 +159,33 @@ module Retriable
     end
   end
 
-  def override_config
-    @override_config
+  def validate_override_options(opts)
+    opts.each_key do |k|
+      raise ArgumentError, "#{k} is not a valid option" unless Config::ATTRIBUTES.include?(k)
+    end
+
+    contexts = opts[:contexts]
+    return unless contexts.is_a?(Hash)
+
+    contexts.each_value do |context_options|
+      validate_context_override_options(context_options)
+    end
+  end
+
+  def validate_context_override_options(context_options)
+    return unless context_options.is_a?(Hash)
+
+    context_attributes = Config::ATTRIBUTES - [:contexts]
+    context_options.each_key do |k|
+      raise ArgumentError, "#{k} is not a valid option" unless context_attributes.include?(k)
+    end
   end
 
   def merge_override_options(options)
-    return options unless override_config
+    return options unless @override_config
 
-    merged_options = options.merge(override_config)
-    clear_intervals_for_forced_tries(merged_options, override_config)
+    merged_options = options.merge(@override_config)
+    clear_intervals_for_forced_tries(merged_options, @override_config)
   end
 
   def clear_intervals_for_forced_tries(options, overrides)
@@ -176,15 +194,11 @@ module Retriable
   end
 
   def merged_contexts
-    return config.contexts unless override_config&.key?(:contexts)
+    override_contexts = @override_config && @override_config[:contexts]
+    return config.contexts unless override_contexts.is_a?(Hash)
 
     base_contexts = config.contexts
-    override_contexts = override_config[:contexts]
-
-    return (base_contexts.is_a?(Hash) ? base_contexts : {}).merge(override_contexts) if override_contexts.is_a?(Hash)
-    return {} if override_contexts.nil?
-
-    base_contexts
+    (base_contexts.is_a?(Hash) ? base_contexts : {}).merge(override_contexts)
   end
 
   def merged_context_options(context_key, options)
@@ -193,9 +207,9 @@ module Retriable
     base = {} unless base.is_a?(Hash)
     context_options = base.merge(options)
 
-    return context_options unless override_config
+    return context_options unless @override_config
 
-    override_contexts = override_config[:contexts]
+    override_contexts = @override_config[:contexts]
     return context_options unless override_contexts.is_a?(Hash)
 
     override_context_options = override_contexts[context_key]
@@ -206,6 +220,8 @@ module Retriable
 
   private_class_method(
     :deep_dup,
+    :validate_override_options,
+    :validate_context_override_options,
     :execute_tries,
     :build_intervals,
     :call_with_timeout,
@@ -213,7 +229,6 @@ module Retriable
     :can_retry?,
     :retriable_exception?,
     :hash_exception_match?,
-    :override_config,
     :merge_override_options,
     :clear_intervals_for_forced_tries,
     :merged_contexts,

--- a/lib/retriable.rb
+++ b/lib/retriable.rb
@@ -8,17 +8,6 @@ require_relative "retriable/version"
 module Retriable
   module_function
 
-  def deep_dup(obj)
-    case obj
-    when Hash
-      obj.each_with_object({}) { |(k, v), h| h[k] = deep_dup(v) }
-    when Array
-      obj.map { |v| deep_dup(v) }
-    else
-      obj
-    end
-  end
-
   def configure
     yield(config)
   end
@@ -31,7 +20,7 @@ module Retriable
     raise ArgumentError, "empty override options are not allowed; use reset_override instead" if opts.empty?
 
     validate_override_options(opts)
-    @override_config = deep_dup(opts).freeze
+    @override_config = opts
   end
 
   def reset_override
@@ -39,7 +28,7 @@ module Retriable
   end
 
   def with_context(context_key, options = {}, &block)
-    contexts = merged_contexts
+    contexts = available_contexts
 
     if !contexts.key?(context_key)
       raise ArgumentError,
@@ -48,18 +37,15 @@ module Retriable
 
     return unless block_given?
 
-    context_options = merged_context_options(context_key, options)
-
-    retriable(context_options, &block)
+    retriable(context_options_for(context_key, options), &block)
   end
 
   def retriable(opts = {}, &block)
-    if opts.empty? && !@override_config
-      local_config = config
-    else
-      local_config_hash = merge_override_options(config.to_h.merge(opts))
-      local_config = Config.new(local_config_hash)
-    end
+    local_config = if opts.empty? && !@override_config
+                     config
+                   else
+                     Config.new(apply_override_options(config.to_h.merge(opts), @override_config))
+                   end
 
     tries = local_config.tries
     intervals = build_intervals(local_config, tries)
@@ -181,45 +167,39 @@ module Retriable
     end
   end
 
-  def merge_override_options(options)
-    return options unless @override_config
+  def apply_override_options(options, overrides)
+    return options unless overrides
 
-    merged_options = options.merge(@override_config)
-    clear_intervals_for_forced_tries(merged_options, @override_config)
-  end
-
-  def clear_intervals_for_forced_tries(options, overrides)
+    options = options.merge(overrides)
     options[:intervals] = nil if overrides.key?(:tries) && !overrides.key?(:intervals)
     options
   end
 
-  def merged_contexts
-    override_contexts = @override_config && @override_config[:contexts]
-    return config.contexts unless override_contexts.is_a?(Hash)
-
-    base_contexts = config.contexts
-    (base_contexts.is_a?(Hash) ? base_contexts : {}).merge(override_contexts)
+  def available_contexts
+    config_contexts.merge(override_contexts)
   end
 
-  def merged_context_options(context_key, options)
-    base_contexts = config.contexts.is_a?(Hash) ? config.contexts : {}
-    base = base_contexts[context_key]
-    base = {} unless base.is_a?(Hash)
-    context_options = base.merge(options)
-
-    return context_options unless @override_config
-
-    override_contexts = @override_config[:contexts]
-    return context_options unless override_contexts.is_a?(Hash)
+  def context_options_for(context_key, options)
+    context_options = config_contexts.fetch(context_key, {})
+    context_options = {} unless context_options.is_a?(Hash)
+    context_options = context_options.merge(options)
 
     override_context_options = override_contexts[context_key]
     return context_options unless override_context_options.is_a?(Hash)
 
-    clear_intervals_for_forced_tries(context_options.merge(override_context_options), override_context_options)
+    apply_override_options(context_options, override_context_options)
+  end
+
+  def config_contexts
+    config.contexts.is_a?(Hash) ? config.contexts : {}
+  end
+
+  def override_contexts
+    contexts = @override_config && @override_config[:contexts]
+    contexts.is_a?(Hash) ? contexts : {}
   end
 
   private_class_method(
-    :deep_dup,
     :validate_override_options,
     :validate_context_override_options,
     :execute_tries,
@@ -229,9 +209,10 @@ module Retriable
     :can_retry?,
     :retriable_exception?,
     :hash_exception_match?,
-    :merge_override_options,
-    :clear_intervals_for_forced_tries,
-    :merged_contexts,
-    :merged_context_options,
+    :apply_override_options,
+    :available_contexts,
+    :context_options_for,
+    :config_contexts,
+    :override_contexts,
   )
 end

--- a/lib/retriable/version.rb
+++ b/lib/retriable/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Retriable
-  VERSION = "3.4.1"
+  VERSION = "3.4.2"
 end

--- a/spec/retriable_spec.rb
+++ b/spec/retriable_spec.rb
@@ -35,6 +35,13 @@ describe Retriable do
   end
 
   context "#retriable" do
+    it "reuses the singleton config when no local options or overrides are provided" do
+      expect(described_class::Config).not_to receive(:new)
+
+      described_class.retriable { increment_tries }
+      expect(@tries).to eq(1)
+    end
+
     it "raises a LocalJumpError if not given a block" do
       expect { described_class.retriable }.to raise_error(LocalJumpError)
       expect { described_class.retriable(timeout: 2) }.to raise_error(LocalJumpError)
@@ -359,6 +366,8 @@ describe Retriable do
         with_context
         configure
         config
+        override
+        reset_override
       ]
 
       expect(described_class.singleton_methods(false)).to match_array(public_api_methods)
@@ -366,6 +375,124 @@ describe Retriable do
 
     it "raises NoMethodError on invalid configuration" do
       expect { described_class.configure { |c| c.does_not_exist = 123 } }.to raise_error(NoMethodError)
+    end
+  end
+
+  context "#override" do
+    after(:each) do
+      described_class.reset_override
+    end
+
+    it "takes precedence over both global config and local options" do
+      described_class.configure { |c| c.tries = 2 }
+      described_class.override(tries: 1)
+
+      expect { described_class.retriable(tries: 10) { increment_tries_with_exception } }.to raise_error(StandardError)
+      expect(@tries).to eq(1)
+    end
+
+    it "can override local intervals with nil to use configured backoff" do
+      described_class.configure { |c| c.tries = 3 }
+      described_class.override(intervals: nil)
+
+      expect do
+        described_class.retriable(intervals: [0.5, 1.0], on_retry: time_table_handler) do
+          increment_tries_with_exception
+        end
+      end.to raise_error(StandardError)
+
+      expect(@tries).to eq(3)
+      expect(@next_interval_table[1]).to be_between(0.0, 1.0)
+    end
+
+    it "applies override context values after with_context local options" do
+      described_class.configure do |c|
+        c.contexts[:api] = { tries: 3, base_interval: 1.0 }
+      end
+
+      described_class.override(contexts: { api: { tries: 1 } })
+
+      described_class.with_context(:api, tries: 10) { increment_tries }
+      expect(@tries).to eq(1)
+    end
+
+    it "can define a context only in override config" do
+      described_class.override(contexts: { test_only: { tries: 1 } })
+
+      described_class.with_context(:test_only) { increment_tries }
+      expect(@tries).to eq(1)
+    end
+
+    it "reuses configured contexts when override does not include contexts" do
+      described_class.configure do |c|
+        c.contexts[:api] = { tries: 1 }
+      end
+
+      described_class.override(tries: 1)
+
+      described_class.with_context(:api) { increment_tries }
+      expect(@tries).to eq(1)
+    end
+
+    it "treats non-hash configured contexts as empty when override contexts are hash" do
+      begin
+        described_class.configure { |c| c.contexts = nil }
+
+        described_class.override(contexts: { api: { tries: 1 } })
+
+        described_class.with_context(:api) { increment_tries }
+        expect(@tries).to eq(1)
+      ensure
+        described_class.configure { |c| c.contexts = {} }
+      end
+    end
+
+    it "treats nil override contexts as empty in with_context" do
+      described_class.override(contexts: nil)
+
+      expect { described_class.with_context(:missing) { increment_tries } }
+        .to raise_error(ArgumentError, /missing not found/)
+    end
+
+    it "ignores non-hash override contexts values in with_context" do
+      described_class.configure do |c|
+        c.contexts[:api] = { tries: 1 }
+      end
+
+      described_class.override(contexts: 123)
+
+      described_class.with_context(:api) { increment_tries }
+      expect(@tries).to eq(1)
+    end
+
+    it "shows merged context keys in with_context missing-context errors" do
+      described_class.configure do |c|
+        c.contexts[:configured] = { tries: 2 }
+      end
+
+      described_class.override(contexts: { override_only: { tries: 1 } })
+
+      expect { described_class.with_context(:missing) { increment_tries } }
+        .to raise_error(ArgumentError, /override_only/)
+    end
+
+    it "does not snapshot configured contexts when adding override-only contexts" do
+      described_class.configure do |c|
+        c.contexts[:api] = { tries: 2 }
+      end
+
+      described_class.override(contexts: { test_only: { tries: 1 } })
+
+      described_class.configure do |c|
+        c.contexts[:api] = { tries: 5 }
+      end
+
+      expect { described_class.with_context(:api) { increment_tries_with_exception } }.to raise_error(StandardError)
+      expect(@tries).to eq(5)
+    end
+
+    it "raises ArgumentError on invalid override options" do
+      expect { described_class.override(does_not_exist: 123) }.to raise_error(ArgumentError)
     end
   end
 

--- a/spec/retriable_spec.rb
+++ b/spec/retriable_spec.rb
@@ -494,6 +494,18 @@ describe Retriable do
     it "raises ArgumentError on invalid override options" do
       expect { described_class.override(does_not_exist: 123) }.to raise_error(ArgumentError)
     end
+
+    it "deep-dups the provided options to prevent external mutation" do
+      opts = { tries: 1 }
+      described_class.override(opts)
+
+      # Mutate the original hash after override was set
+      opts[:tries] = 99
+
+      # Override should still use the original value (tries: 1), not the mutated one
+      expect { described_class.retriable(tries: 10) { increment_tries_with_exception } }.to raise_error(StandardError)
+      expect(@tries).to eq(1)
+    end
   end
 
   context "#with_context" do
@@ -542,6 +554,15 @@ describe Retriable do
 
     it "raises an ArgumentError when the context isn't found" do
       expect { described_class.with_context(:wtf) { increment_tries } }.to raise_error(ArgumentError, /wtf not found/)
+    end
+
+    it "treats non-Hash context values as empty options" do
+      described_class.configure do |c|
+        c.contexts[:broken] = nil
+      end
+
+      described_class.with_context(:broken) { increment_tries }
+      expect(@tries).to eq(1)
     end
   end
 end

--- a/spec/retriable_spec.rb
+++ b/spec/retriable_spec.rb
@@ -554,16 +554,14 @@ describe Retriable do
         .to raise_error(ArgumentError, /does_not_exist is not a valid option/)
     end
 
-    it "deep-dups the provided options to prevent external mutation" do
+    it "does not copy the provided override options" do
       opts = { tries: 1 }
       described_class.override(opts)
 
-      # Mutate the original hash after override was set
-      opts[:tries] = 99
+      opts[:tries] = 2
 
-      # Override should still use the original value (tries: 1), not the mutated one
       expect { described_class.retriable(tries: 10) { increment_tries_with_exception } }.to raise_error(StandardError)
-      expect(@tries).to eq(1)
+      expect(@tries).to eq(2)
     end
   end
 

--- a/spec/retriable_spec.rb
+++ b/spec/retriable_spec.rb
@@ -493,11 +493,15 @@ describe Retriable do
       end
     end
 
-    it "treats nil override contexts as empty in with_context" do
+    it "ignores nil override contexts values in with_context" do
+      described_class.configure do |c|
+        c.contexts[:api] = { tries: 1 }
+      end
+
       described_class.override(contexts: nil)
 
-      expect { described_class.with_context(:missing) { increment_tries } }
-        .to raise_error(ArgumentError, /missing not found/)
+      described_class.with_context(:api) { increment_tries }
+      expect(@tries).to eq(1)
     end
 
     it "ignores non-hash override contexts values in with_context" do
@@ -539,6 +543,15 @@ describe Retriable do
 
     it "raises ArgumentError on invalid override options" do
       expect { described_class.override(does_not_exist: 123) }.to raise_error(ArgumentError)
+    end
+
+    it "raises ArgumentError on empty override options" do
+      expect { described_class.override({}) }.to raise_error(ArgumentError, /empty override/)
+    end
+
+    it "raises ArgumentError on invalid context override options" do
+      expect { described_class.override(contexts: { api: { does_not_exist: 123 } }) }
+        .to raise_error(ArgumentError, /does_not_exist is not a valid option/)
     end
 
     it "deep-dups the provided options to prevent external mutation" do

--- a/spec/retriable_spec.rb
+++ b/spec/retriable_spec.rb
@@ -1,11 +1,15 @@
 # frozen_string_literal: true
 
+require "rbconfig"
+
 describe Retriable do
   let(:time_table_handler) do
     ->(_exception, try, _elapsed_time, next_interval) { @next_interval_table[try] = next_interval }
   end
 
   before(:each) do
+    described_class.instance_variable_set(:@config, nil)
+    described_class.reset_override
     described_class.configure { |c| c.sleep_disabled = true }
     @tries = 0
     @next_interval_table = {}
@@ -23,7 +27,9 @@ describe Retriable do
 
   context "global scope extension" do
     it "cannot be called in the global scope without requiring the core_ext/kernel" do
-      expect { retriable { puts "should raise NoMethodError" } }.to raise_error(NoMethodError)
+      script = "require 'retriable'; begin; retriable {}; rescue NoMethodError; exit 0; end; exit 1"
+
+      expect(system(RbConfig.ruby, "-Ilib", "-e", script)).to be(true)
     end
 
     it "can be called once the kernel extension is required" do
@@ -388,6 +394,46 @@ describe Retriable do
       described_class.override(tries: 1)
 
       expect { described_class.retriable(tries: 10) { increment_tries_with_exception } }.to raise_error(StandardError)
+      expect(@tries).to eq(1)
+    end
+
+    it "lets override tries take precedence over local intervals" do
+      described_class.override(tries: 1)
+
+      expect do
+        described_class.retriable(intervals: [0.5, 1.0]) { increment_tries_with_exception }
+      end.to raise_error(StandardError)
+
+      expect(@tries).to eq(1)
+    end
+
+    it "lets override tries take precedence over context intervals" do
+      described_class.configure do |c|
+        c.contexts[:api] = { intervals: [0.5, 1.0] }
+      end
+      described_class.override(tries: 1)
+
+      expect { described_class.with_context(:api) { increment_tries_with_exception } }.to raise_error(StandardError)
+      expect(@tries).to eq(1)
+    end
+
+    it "lets override context tries take precedence over context intervals" do
+      described_class.configure do |c|
+        c.contexts[:api] = { intervals: [0.5, 1.0] }
+      end
+      described_class.override(contexts: { api: { tries: 1 } })
+
+      expect { described_class.with_context(:api) { increment_tries_with_exception } }.to raise_error(StandardError)
+      expect(@tries).to eq(1)
+    end
+
+    it "replaces hash-valued options instead of deep-merging them" do
+      described_class.override(on: { NonStandardError => nil })
+
+      expect do
+        described_class.retriable(on: { StandardError => nil }, tries: 2) { increment_tries_with_exception }
+      end.to raise_error(StandardError)
+
       expect(@tries).to eq(1)
     end
 


### PR DESCRIPTION
## Summary

Adds `Retriable.override` and `Retriable.reset_override` APIs that force retry settings over local call options.

```ruby
Retriable.override(tries: 1, base_interval: 0)
```

### Precedence

```
override > local options > configure defaults
```

### Use case

Test short-circuiting: in test environments, `tries: 1` must win even when production code passes explicit local options like `Retriable.retriable(tries: 5)`. Overrides also force retry behavior over inherited custom `intervals` unless `intervals` is explicitly overridden.

### API

- `Retriable.override(opts)` accepts a non-empty hash of config keys to force globally.
- `Retriable.reset_override` clears the override.
- Contexts are supported: `Retriable.override(contexts: { api: { tries: 1 } })`.
- Invalid top-level keys and invalid context override keys raise `ArgumentError`, consistent with `Retriable.retriable`.

### Example: Rails test setup

```ruby
# config/initializers/retriable.rb
Retriable.configure do |c|
  c.tries = 3
  c.base_interval = 0.5
end

if Rails.env.test?
  Retriable.override(tries: 1, base_interval: 0, rand_factor: 0)
end
```

### Implementation

The override is stored as a sparse hash delta and merged lazily at each `retriable`/`with_context` call. Hash-valued options replace lower-precedence values rather than deep-merging, so forced options remain authoritative.

### Changes

- `lib/retriable.rb` — adds `override`, `reset_override`, validation, and supporting merge helpers
- `spec/retriable_spec.rb` — tests override precedence, contexts, edge cases, validation, and order isolation
- `README.md` — new Override section, updated Testing section with override examples
- `CHANGELOG.md` / `lib/retriable/version.rb` — version and changelog entries

Closes #108.