### PR TITLE
Fix sleep-disabled max elapsed retries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # HEAD
 
+- Fix: Do not count skipped sleep intervals against `max_elapsed_time` when `sleep_disabled` is true.
 - Add `override` and `reset_override` APIs to force retry settings over local call options when needed (for example, test short-circuiting).
 
 ## 3.4.1

--- a/lib/retriable.rb
+++ b/lib/retriable.rb
@@ -86,7 +86,8 @@ module Retriable
         interval = intervals[index]
         call_on_retry(on_retry, e, try, elapsed_time.call, interval)
 
-        raise unless can_retry?(try, tries, elapsed_time.call, interval, max_elapsed_time)
+        elapsed_interval = sleep_disabled == true ? 0 : interval
+        raise unless can_retry?(try, tries, elapsed_time.call, elapsed_interval, max_elapsed_time)
 
         sleep interval if sleep_disabled != true
       end

--- a/spec/retriable_spec.rb
+++ b/spec/retriable_spec.rb
@@ -329,6 +329,8 @@ describe Retriable do
     end
 
     it "does not count skipped sleep intervals against max elapsed time" do
+      allow(Process).to receive(:clock_gettime).with(Process::CLOCK_MONOTONIC).and_return(0.0)
+
       expect do
         described_class.retriable(tries: 3, base_interval: 1.0, rand_factor: 0.0, max_elapsed_time: 0.1) do
           increment_tries_with_exception

--- a/spec/retriable_spec.rb
+++ b/spec/retriable_spec.rb
@@ -328,6 +328,16 @@ describe Retriable do
       expect(@tries).to eq(2)
     end
 
+    it "does not count skipped sleep intervals against max elapsed time" do
+      expect do
+        described_class.retriable(tries: 3, base_interval: 1.0, rand_factor: 0.0, max_elapsed_time: 0.1) do
+          increment_tries_with_exception
+        end
+      end.to raise_error(StandardError)
+
+      expect(@tries).to eq(3)
+    end
+
     it "retries up to tries limit when max_elapsed_time is nil" do
       expect do
         described_class.retriable(tries: 4, max_elapsed_time: nil) { increment_tries_with_exception }


### PR DESCRIPTION
## Summary
- Treat skipped sleep intervals as zero when enforcing max_elapsed_time
- Add a regression spec with stubbed monotonic time for deterministic coverage

## Test Plan
- bundle exec rspec
- bundle exec rubocop lib/retriable.rb spec/retriable_spec.rb

## Notes
- Full bundle exec rake still hits existing repo-wide RuboCop offenses outside this PR.