### PR TITLE
Harden CI workflow permissions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,6 +7,9 @@ on:
     branches: [main]
     types: [opened, synchronize, reopened]
 
+permissions:
+  contents: read
+
 jobs:
   ci:
     # The type of runner that the job will run on
@@ -34,10 +37,10 @@ jobs:
 
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Setup ruby
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@afeafc3d1ab54a631816aba4c914a0081c12ff2f # v1
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true


### PR DESCRIPTION
## Summary
- Add least-privilege GitHub Actions token permissions
- Pin checkout and setup-ruby actions to resolved commit SHAs

## Test Plan
- ruby -e "require 'yaml'; YAML.load_file('.github/workflows/main.yml'); puts 'workflow yaml parses'"\n- bundle exec rspec\n\n## Notes\n- Full bundle exec rake still hits existing repo-wide RuboCop offenses outside this PR.