### PR TITLE
Harden retry timing option validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # HEAD
 
+- Fix: Validate retry timing and count options before use to reject invalid retry configurations.
+
 ## 3.5.0
 
 - Fix: Do not count skipped sleep intervals against `max_elapsed_time` when `sleep_disabled` is true.

--- a/lib/retriable.rb
+++ b/lib/retriable.rb
@@ -49,8 +49,8 @@ module Retriable
 
     local_config.validate!
 
-    tries = effective_tries(local_config)
-    next_interval = interval_provider(local_config, tries)
+    tries = local_config.tries
+    intervals = build_intervals(local_config, tries)
     timeout = local_config.timeout
     on = local_config.on
     retry_if = local_config.retry_if
@@ -63,8 +63,10 @@ module Retriable
     start_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
     elapsed_time = -> { Process.clock_gettime(Process::CLOCK_MONOTONIC) - start_time }
 
+    tries = intervals.size + 1
+
     execute_tries(
-      tries: tries, next_interval: next_interval, timeout: timeout,
+      tries: tries, intervals: intervals, timeout: timeout,
       exception_list: exception_list, on: on, retry_if: retry_if, on_retry: on_retry,
       elapsed_time: elapsed_time, max_elapsed_time: max_elapsed_time,
       sleep_disabled: sleep_disabled, &block
@@ -72,7 +74,7 @@ module Retriable
   end
 
   def execute_tries( # rubocop:disable Metrics/ParameterLists
-    tries:, next_interval:, timeout:, exception_list:,
+    tries:, intervals:, timeout:, exception_list:,
     on:, retry_if:, on_retry:, elapsed_time:, max_elapsed_time:, sleep_disabled:, &block
   )
     tries.times do |index|
@@ -83,7 +85,7 @@ module Retriable
       rescue *exception_list => e
         raise unless retriable_exception?(e, on, exception_list, retry_if)
 
-        interval = next_interval.call(index)
+        interval = intervals[index]
         call_on_retry(on_retry, e, try, elapsed_time.call, interval)
 
         elapsed_interval = sleep_disabled == true ? 0 : interval
@@ -94,28 +96,16 @@ module Retriable
     end
   end
 
-  def effective_tries(local_config)
-    return local_config.intervals.size + 1 if local_config.intervals
+  def build_intervals(local_config, tries)
+    return local_config.intervals if local_config.intervals
 
-    local_config.tries
-  end
-
-  def interval_provider(local_config, tries)
-    return ->(index) { local_config.intervals[index] } if local_config.intervals
-
-    backoff = nil
-    lambda do |index|
-      next nil if index >= tries - 1
-
-      backoff ||= ExponentialBackoff.new(
-        tries: tries - 1,
-        base_interval: local_config.base_interval,
-        multiplier: local_config.multiplier,
-        max_interval: local_config.max_interval,
-        rand_factor: local_config.rand_factor,
-      )
-      backoff.interval_at(index)
-    end
+    ExponentialBackoff.new(
+      tries: tries - 1,
+      base_interval: local_config.base_interval,
+      multiplier: local_config.multiplier,
+      max_interval: local_config.max_interval,
+      rand_factor: local_config.rand_factor,
+    ).intervals
   end
 
   def call_with_timeout(timeout, try)
@@ -216,8 +206,7 @@ module Retriable
     :validate_override_options,
     :validate_context_override_options,
     :execute_tries,
-    :effective_tries,
-    :interval_provider,
+    :build_intervals,
     :call_with_timeout,
     :call_on_retry,
     :can_retry?,

--- a/lib/retriable.rb
+++ b/lib/retriable.rb
@@ -47,8 +47,10 @@ module Retriable
                      Config.new(apply_override_options(config.to_h.merge(opts), @override_config))
                    end
 
-    tries = local_config.tries
-    intervals = build_intervals(local_config, tries)
+    local_config.validate!
+
+    tries = effective_tries(local_config)
+    next_interval = interval_provider(local_config, tries)
     timeout = local_config.timeout
     on = local_config.on
     retry_if = local_config.retry_if
@@ -61,10 +63,8 @@ module Retriable
     start_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
     elapsed_time = -> { Process.clock_gettime(Process::CLOCK_MONOTONIC) - start_time }
 
-    tries = intervals.size + 1
-
     execute_tries(
-      tries: tries, intervals: intervals, timeout: timeout,
+      tries: tries, next_interval: next_interval, timeout: timeout,
       exception_list: exception_list, on: on, retry_if: retry_if, on_retry: on_retry,
       elapsed_time: elapsed_time, max_elapsed_time: max_elapsed_time,
       sleep_disabled: sleep_disabled, &block
@@ -72,7 +72,7 @@ module Retriable
   end
 
   def execute_tries( # rubocop:disable Metrics/ParameterLists
-    tries:, intervals:, timeout:, exception_list:,
+    tries:, next_interval:, timeout:, exception_list:,
     on:, retry_if:, on_retry:, elapsed_time:, max_elapsed_time:, sleep_disabled:, &block
   )
     tries.times do |index|
@@ -83,7 +83,7 @@ module Retriable
       rescue *exception_list => e
         raise unless retriable_exception?(e, on, exception_list, retry_if)
 
-        interval = intervals[index]
+        interval = next_interval.call(index)
         call_on_retry(on_retry, e, try, elapsed_time.call, interval)
 
         elapsed_interval = sleep_disabled == true ? 0 : interval
@@ -94,16 +94,28 @@ module Retriable
     end
   end
 
-  def build_intervals(local_config, tries)
-    return local_config.intervals if local_config.intervals
+  def effective_tries(local_config)
+    return local_config.intervals.size + 1 if local_config.intervals
 
-    ExponentialBackoff.new(
-      tries: tries - 1,
-      base_interval: local_config.base_interval,
-      multiplier: local_config.multiplier,
-      max_interval: local_config.max_interval,
-      rand_factor: local_config.rand_factor,
-    ).intervals
+    local_config.tries
+  end
+
+  def interval_provider(local_config, tries)
+    return ->(index) { local_config.intervals[index] } if local_config.intervals
+
+    backoff = nil
+    lambda do |index|
+      next nil if index >= tries - 1
+
+      backoff ||= ExponentialBackoff.new(
+        tries: tries - 1,
+        base_interval: local_config.base_interval,
+        multiplier: local_config.multiplier,
+        max_interval: local_config.max_interval,
+        rand_factor: local_config.rand_factor,
+      )
+      backoff.interval_at(index)
+    end
   end
 
   def call_with_timeout(timeout, try)
@@ -204,7 +216,8 @@ module Retriable
     :validate_override_options,
     :validate_context_override_options,
     :execute_tries,
-    :build_intervals,
+    :effective_tries,
+    :interval_provider,
     :call_with_timeout,
     :call_on_retry,
     :can_retry?,

--- a/lib/retriable/config.rb
+++ b/lib/retriable/config.rb
@@ -39,12 +39,63 @@ module Retriable
 
         instance_variable_set(:"@#{k}", v)
       end
+
+      validate!
     end
 
     def to_h
       ATTRIBUTES.each_with_object({}) do |key, hash|
         hash[key] = public_send(key)
       end
+    end
+
+    def validate!
+      validate_positive_integer(:tries, tries)
+      validate_non_negative_number(:base_interval, base_interval)
+      validate_non_negative_number(:multiplier, multiplier)
+      validate_non_negative_number(:max_interval, max_interval)
+      validate_rand_factor
+      validate_optional_non_negative_number(:max_elapsed_time, max_elapsed_time)
+      validate_optional_non_negative_number(:timeout, timeout)
+      validate_intervals
+    end
+
+    private
+
+    def validate_positive_integer(name, value)
+      return if value.is_a?(Integer) && value.positive?
+
+      raise ArgumentError, "#{name} must be a positive integer"
+    end
+
+    def validate_non_negative_number(name, value)
+      return if finite_number?(value) && value >= 0
+
+      raise ArgumentError, "#{name} must be a non-negative number"
+    end
+
+    def validate_optional_non_negative_number(name, value)
+      return if value.nil?
+
+      validate_non_negative_number(name, value)
+    end
+
+    def validate_rand_factor
+      return if finite_number?(rand_factor) && rand_factor >= 0 && rand_factor <= 1
+
+      raise ArgumentError, "rand_factor must be between 0 and 1"
+    end
+
+    def validate_intervals
+      return if intervals.nil?
+      raise ArgumentError, "intervals must be an Array" unless intervals.is_a?(Array)
+      return if intervals.all? { |interval| finite_number?(interval) && interval >= 0 }
+
+      raise ArgumentError, "intervals must contain only non-negative numbers"
+    end
+
+    def finite_number?(value)
+      value.is_a?(Numeric) && value.to_f.finite?
     end
   end
 end

--- a/lib/retriable/config.rb
+++ b/lib/retriable/config.rb
@@ -50,14 +50,16 @@ module Retriable
     end
 
     def validate!
+      validate_optional_non_negative_number(:max_elapsed_time, max_elapsed_time)
+      validate_optional_non_negative_number(:timeout, timeout)
+      validate_intervals
+      return if intervals
+
       validate_positive_integer(:tries, tries)
       validate_non_negative_number(:base_interval, base_interval)
       validate_non_negative_number(:multiplier, multiplier)
       validate_non_negative_number(:max_interval, max_interval)
       validate_rand_factor
-      validate_optional_non_negative_number(:max_elapsed_time, max_elapsed_time)
-      validate_optional_non_negative_number(:timeout, timeout)
-      validate_intervals
     end
 
     private

--- a/lib/retriable/exponential_backoff.rb
+++ b/lib/retriable/exponential_backoff.rb
@@ -29,29 +29,29 @@ module Retriable
     end
 
     def intervals
-      Array.new(tries) { |iteration| interval_at(iteration) }
-    end
+      intervals = Array.new(tries) do |iteration|
+        [base_interval * (multiplier**iteration), max_interval].min
+      end
 
-    def interval_at(iteration)
-      interval = [base_interval * (multiplier**iteration), max_interval].min
+      return intervals if rand_factor.zero?
 
-      rand_factor.zero? ? interval : randomize(interval)
+      intervals.map { |i| randomize(i) }
     end
 
     private
 
     def validate!
-      validate_positive_integer(:tries, tries)
+      validate_non_negative_integer(:tries, tries)
       validate_non_negative_number(:base_interval, base_interval)
       validate_non_negative_number(:multiplier, multiplier)
       validate_non_negative_number(:max_interval, max_interval)
       validate_rand_factor
     end
 
-    def validate_positive_integer(name, value)
-      return if value.is_a?(Integer) && value.positive?
+    def validate_non_negative_integer(name, value)
+      return if value.is_a?(Integer) && value >= 0
 
-      raise ArgumentError, "#{name} must be a positive integer"
+      raise ArgumentError, "#{name} must be a non-negative integer"
     end
 
     def validate_non_negative_number(name, value)

--- a/lib/retriable/exponential_backoff.rb
+++ b/lib/retriable/exponential_backoff.rb
@@ -24,19 +24,51 @@ module Retriable
 
         instance_variable_set(:"@#{k}", v)
       end
+
+      validate!
     end
 
     def intervals
-      intervals = Array.new(tries) do |iteration|
-        [base_interval * (multiplier**iteration), max_interval].min
-      end
+      Array.new(tries) { |iteration| interval_at(iteration) }
+    end
 
-      return intervals if rand_factor.zero?
+    def interval_at(iteration)
+      interval = [base_interval * (multiplier**iteration), max_interval].min
 
-      intervals.map { |i| randomize(i) }
+      rand_factor.zero? ? interval : randomize(interval)
     end
 
     private
+
+    def validate!
+      validate_positive_integer(:tries, tries)
+      validate_non_negative_number(:base_interval, base_interval)
+      validate_non_negative_number(:multiplier, multiplier)
+      validate_non_negative_number(:max_interval, max_interval)
+      validate_rand_factor
+    end
+
+    def validate_positive_integer(name, value)
+      return if value.is_a?(Integer) && value.positive?
+
+      raise ArgumentError, "#{name} must be a positive integer"
+    end
+
+    def validate_non_negative_number(name, value)
+      return if finite_number?(value) && value >= 0
+
+      raise ArgumentError, "#{name} must be a non-negative number"
+    end
+
+    def validate_rand_factor
+      return if finite_number?(rand_factor) && rand_factor >= 0 && rand_factor <= 1
+
+      raise ArgumentError, "rand_factor must be between 0 and 1"
+    end
+
+    def finite_number?(value)
+      value.is_a?(Numeric) && value.to_f.finite?
+    end
 
     def randomize(interval)
       delta = rand_factor * interval.to_f

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -56,4 +56,9 @@ describe Retriable::Config do
   it "raises errors on invalid configuration" do
     expect { described_class.new(does_not_exist: 123) }.to raise_error(ArgumentError, /not a valid option/)
   end
+
+  it "raises errors on invalid timing configuration" do
+    expect { described_class.new(rand_factor: 1.1) }.to raise_error(ArgumentError, /rand_factor/)
+    expect { described_class.new(timeout: -1) }.to raise_error(ArgumentError, /timeout/)
+  end
 end

--- a/spec/retriable_spec.rb
+++ b/spec/retriable_spec.rb
@@ -48,6 +48,13 @@ describe Retriable do
       expect(@tries).to eq(1)
     end
 
+    it "does not build generated intervals when the first attempt succeeds" do
+      expect(described_class::ExponentialBackoff).not_to receive(:new)
+
+      described_class.retriable { increment_tries }
+      expect(@tries).to eq(1)
+    end
+
     it "raises a LocalJumpError if not given a block" do
       expect { described_class.retriable }.to raise_error(LocalJumpError)
       expect { described_class.retriable(timeout: 2) }.to raise_error(LocalJumpError)
@@ -374,6 +381,16 @@ describe Retriable do
 
     it "raises ArgumentError on invalid options" do
       expect { described_class.retriable(does_not_exist: 123) { increment_tries } }.to raise_error(ArgumentError)
+    end
+
+    it "raises ArgumentError when tries is not a positive integer" do
+      expect { described_class.retriable(tries: 1.5) { increment_tries } }
+        .to raise_error(ArgumentError, /tries/)
+    end
+
+    it "raises ArgumentError when an interval is negative" do
+      expect { described_class.retriable(intervals: [-1]) { increment_tries } }
+        .to raise_error(ArgumentError, /intervals/)
     end
   end
 

--- a/spec/retriable_spec.rb
+++ b/spec/retriable_spec.rb
@@ -48,13 +48,6 @@ describe Retriable do
       expect(@tries).to eq(1)
     end
 
-    it "does not build generated intervals when the first attempt succeeds" do
-      expect(described_class::ExponentialBackoff).not_to receive(:new)
-
-      described_class.retriable { increment_tries }
-      expect(@tries).to eq(1)
-    end
-
     it "raises a LocalJumpError if not given a block" do
       expect { described_class.retriable }.to raise_error(LocalJumpError)
       expect { described_class.retriable(timeout: 2) }.to raise_error(LocalJumpError)
@@ -391,6 +384,12 @@ describe Retriable do
     it "raises ArgumentError when an interval is negative" do
       expect { described_class.retriable(intervals: [-1]) { increment_tries } }
         .to raise_error(ArgumentError, /intervals/)
+    end
+
+    it "does not validate generated backoff options when intervals are provided" do
+      described_class.retriable(intervals: [0], tries: 0, rand_factor: 1.1) { increment_tries }
+
+      expect(@tries).to eq(1)
     end
   end
 


### PR DESCRIPTION
## Summary
- Validate retry timing/count options before use
- Reject invalid generated backoff values and negative custom intervals
- Preserve documented custom intervals precedence over generated backoff options

## Test Plan
- bundle exec rspec
- bundle exec rubocop lib/retriable.rb lib/retriable/config.rb lib/retriable/exponential_backoff.rb spec/retriable_spec.rb spec/config_spec.rb

## Notes
- Lazy generated interval construction was deferred after review because it can change global RNG behavior for callers that use rand inside retried blocks.
- Full bundle exec rake still hits existing repo-wide RuboCop offenses outside this PR.