### PR TITLE
Validate on: option against non-Exception values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # HEAD
 
+## 3.6.1
+
+- Fix: Validate the `on:` option before retrying. Previously, passing a non-`Exception` value such as `Object`, `Kernel`, or a plain `Module` (which appear in every `Exception`'s ancestor chain) would silently retry process-critical exceptions like `SystemExit` and `Interrupt`. The `on:` option now requires an `Exception` subclass, an array of them, or a hash whose keys are such classes and whose values are `nil`, a `Regexp`, or an array of `Regexp`s. Invalid shapes raise `ArgumentError` before the block runs.
+
 ## 3.6.0
 
 - Breaking: `Retriable.override` and `Retriable.reset_override` are removed and replaced by block-scoped `Retriable.with_override(opts) { ... }`. The new API requires a block, restores the previous override (or absence of override) when the block exits via `ensure`, and is thread-local — overrides set in one thread do not affect other threads, and child threads do not inherit them. Fibers within a thread still share the thread's active override. Nested `with_override` calls correctly restore the outer override on inner exit. See the README and `docs/testing.md` for migration and testing patterns. This replaces the override API introduced in 3.5.0.

--- a/lib/retriable/config.rb
+++ b/lib/retriable/config.rb
@@ -55,6 +55,7 @@ module Retriable
     def validate!
       validate_optional_non_negative_number(:max_elapsed_time, max_elapsed_time)
       validate_optional_non_negative_number(:timeout, timeout)
+      validate_on(on)
       validate_intervals
       return if intervals
 

--- a/lib/retriable/validation.rb
+++ b/lib/retriable/validation.rb
@@ -37,5 +37,46 @@ module Retriable
     def finite_number?(value)
       value.is_a?(Numeric) && value.to_f.finite?
     end
+
+    # Validates an `on:` value. Acceptable shapes:
+    #   - a Class that descends from Exception
+    #   - an Array whose elements are Classes that descend from Exception
+    #   - a Hash whose keys are such Classes and whose values are nil,
+    #     a Regexp, or an Array of Regexps
+    #
+    # Without this validation, callers can pass values like `Object` or
+    # `Kernel` and silently retry process-critical exceptions such as
+    # SystemExit and Interrupt, because every Exception's ancestor chain
+    # includes both. Hash values that are not Regexps (e.g. plain Strings)
+    # also silently fail to match in #hash_exception_match?, so we require
+    # Regexp values explicitly.
+    def validate_on(value)
+      case value
+      when Hash
+        value.each do |klass, pattern|
+          validate_on_class(klass)
+          validate_on_hash_value(klass, pattern)
+        end
+      when Array
+        value.each { |klass| validate_on_class(klass) }
+      else
+        validate_on_class(value)
+      end
+    end
+
+    def validate_on_class(klass)
+      return if klass.is_a?(Class) && klass <= Exception
+
+      raise ArgumentError, "on must be an Exception class or a collection of Exception classes, got #{klass.inspect}"
+    end
+
+    def validate_on_hash_value(klass, pattern)
+      return if pattern.nil?
+      return if pattern.is_a?(Regexp)
+      return if pattern.is_a?(Array) && pattern.all? { |p| p.is_a?(Regexp) }
+
+      raise ArgumentError,
+            "on[#{klass}] must be nil, a Regexp, or an Array of Regexps, got #{pattern.inspect}"
+    end
   end
 end

--- a/lib/retriable/version.rb
+++ b/lib/retriable/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Retriable
-  VERSION = "3.6.0"
+  VERSION = "3.6.1"
 end

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -65,4 +65,70 @@ describe Retriable::Config do
   it "raises errors when intervals is not an array" do
     expect { described_class.new(intervals: "1") }.to raise_error(ArgumentError, /intervals must be an Array/)
   end
+
+  context "on: option validation" do
+    it "accepts a single Exception subclass" do
+      expect { described_class.new(on: StandardError) }.not_to raise_error
+    end
+
+    it "accepts Exception itself" do
+      expect { described_class.new(on: Exception) }.not_to raise_error
+    end
+
+    it "accepts an array of Exception subclasses" do
+      expect { described_class.new(on: [StandardError, RuntimeError]) }.not_to raise_error
+    end
+
+    it "accepts a hash with nil pattern values" do
+      expect { described_class.new(on: { StandardError => nil }) }.not_to raise_error
+    end
+
+    it "accepts a hash with Regexp pattern values" do
+      expect { described_class.new(on: { StandardError => /boom/ }) }.not_to raise_error
+    end
+
+    it "accepts a hash with Array-of-Regexp pattern values" do
+      expect { described_class.new(on: { StandardError => [/a/, /b/] }) }.not_to raise_error
+    end
+
+    it "rejects Object as on:" do
+      expect { described_class.new(on: Object) }
+        .to raise_error(ArgumentError, /on must be an Exception class/)
+    end
+
+    it "rejects Kernel as on:" do
+      expect { described_class.new(on: Kernel) }
+        .to raise_error(ArgumentError, /on must be an Exception class/)
+    end
+
+    it "rejects an array containing a non-Exception class" do
+      expect { described_class.new(on: [StandardError, Kernel]) }
+        .to raise_error(ArgumentError, /on must be an Exception class/)
+    end
+
+    it "rejects a hash key that is not an Exception class" do
+      expect { described_class.new(on: { Kernel => nil }) }
+        .to raise_error(ArgumentError, /on must be an Exception class/)
+    end
+
+    it "rejects a hash value that is a String" do
+      expect { described_class.new(on: { StandardError => "boom" }) }
+        .to raise_error(ArgumentError, /on\[StandardError\] must be nil, a Regexp, or an Array of Regexps/)
+    end
+
+    it "rejects a hash value that is an Array containing a non-Regexp" do
+      expect { described_class.new(on: { StandardError => [/a/, "b"] }) }
+        .to raise_error(ArgumentError, /on\[StandardError\] must be nil, a Regexp, or an Array of Regexps/)
+    end
+
+    it "rejects a string passed as on:" do
+      expect { described_class.new(on: "StandardError") }
+        .to raise_error(ArgumentError, /on must be an Exception class/)
+    end
+
+    it "validates on: even when intervals is provided" do
+      expect { described_class.new(intervals: [0.1], on: Object) }
+        .to raise_error(ArgumentError, /on must be an Exception class/)
+    end
+  end
 end

--- a/spec/retriable_spec.rb
+++ b/spec/retriable_spec.rb
@@ -406,6 +406,16 @@ describe Retriable do
 
       expect(@tries).to eq(1)
     end
+
+    it "rejects on: Object before invoking the block" do
+      block_invoked = false
+
+      expect do
+        described_class.retriable(on: Object) { block_invoked = true }
+      end.to raise_error(ArgumentError, /on must be an Exception class/)
+
+      expect(block_invoked).to be(false)
+    end
   end
 
   context "#configure" do


### PR DESCRIPTION
## Summary
- Add `validate_on` to `Retriable::Validation` that rejects `on:` values which are not `Exception` subclasses (single, array, or hash keys), and rejects hash values that are not `nil`/`Regexp`/`Array<Regexp>`
- Wire `validate_on(on)` into `Config#validate!` so per-call, configured, and overridden `on:` values are all checked before the block runs
- Add config-level and retriable-level specs covering accepted shapes and the rejected footguns (`Object`, `Kernel`, mixed arrays, non-Regexp hash values, strings)
- Bump to 3.6.1 and add CHANGELOG entry

## Motivation
`rescue *list` in Ruby matches anything in an exception's ancestor chain. Every `Exception` includes `Kernel` and descends from `Object`, so previously `Retriable.retriable(on: Object) { exit }` would silently retry `SystemExit` instead of letting the process exit. Validation now rejects these shapes with a clear `ArgumentError` before the block runs.

## Test Plan
- [x] bundle exec rspec (115 examples, 0 failures)
- [x] bundle exec rubocop lib/retriable/validation.rb lib/retriable/config.rb lib/retriable/version.rb spec/config_spec.rb spec/retriable_spec.rb (no offenses)

## Notes
- `on: Exception` itself remains allowed; rejecting it would be a stronger opinion than this fix targets.
- Full `bundle exec rubocop` still reports pre-existing unrelated offenses in `retriable.gemspec` and `spec/exponential_backoff_spec.rb`.