### PR TITLE
Document on_retry: false sentinel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 3.6.1
 
 - Fix: Validate the `on:` option before retrying. Previously, passing a non-`Exception` value such as `Object`, `Kernel`, or a plain `Module` (which appear in every `Exception`'s ancestor chain) would silently retry process-critical exceptions like `SystemExit` and `Interrupt`. The `on:` option now requires an `Exception` subclass, an array of them, or a hash whose keys are such classes and whose values are `nil`, a `Regexp`, or an array of `Regexp`s. Invalid shapes raise `ArgumentError` before the block runs.
+- Docs: Document that `on_retry: false` disables a callback set in `Retriable.configure` for a single call.
 
 ## 3.6.0
 

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ Here are the available options, in some vague order of relevance to most common 
 | **`tries`**            | `3`               | Number of attempts to make at running your code block (includes initial attempt).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
 | **`on`**               | `[StandardError]` | Type of exceptions to retry. [Read more](#configuring-which-options-to-retry-with-on).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
 | **`retry_if`**         | `nil`             | Callable (for example a `Proc` or lambda) that receives the rescued exception and returns true/false to decide whether to retry. [Read more](#advanced-retry-matching-with-retry_if).                                                                                                                                                                                                                                                                                                                                                                                                                                 |
-| **`on_retry`**         | `nil`             | `Proc` to call after each try is rescued. [Read more](#callbacks).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
+| **`on_retry`**         | `nil`             | `Proc` to call after each try is rescued. Pass `false` to disable a callback set in `#configure` for a single call. [Read more](#callbacks).                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
 | **`sleep_disabled`**   | `false`           | When true, disable exponential backoff and attempt retries immediately.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
 | **`base_interval`**    | `0.5`             | The initial interval in seconds between tries.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
 | **`max_elapsed_time`** | `900` (15 min)    | The maximum amount of total time in seconds that code is allowed to keep being retried. Set to `nil` to disable the time limit and retry based solely on `tries`.                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
@@ -314,6 +314,26 @@ end
 
 Retriable.retriable(on_retry: do_this_on_each_retry) do
   # code here...
+end
+```
+
+#### Disabling a Configured Callback Per Call
+
+If `on_retry` is set in `Retriable.configure`, every call uses it by default. To opt a specific call out — for example, a critical call site that should not log on retry — pass `on_retry: false`. Passing `nil` does not work for this purpose because per-call options are merged over configured defaults; `false` is the explicit "disabled" sentinel.
+
+```ruby
+Retriable.configure do |c|
+  c.on_retry = ->(exception, try, elapsed_time, next_interval) { log(...) }
+end
+
+# Most calls use the configured callback.
+Retriable.retriable do
+  # ...
+end
+
+# This specific call opts out of the configured callback.
+Retriable.retriable(on_retry: false) do
+  # ...
 end
 ```
 


### PR DESCRIPTION
## Summary
- Update the `on_retry` row in the README options table to mention that `false` disables a callback set in `#configure` for a single call
- Add a "Disabling a Configured Callback Per Call" subsection under `### Callbacks` with an example showing the configure + `on_retry: false` pattern
- Add a `Docs:` line to the 3.6.1 CHANGELOG entry

## Motivation
`call_on_retry` short-circuits on any falsy `on_retry` value, so passing `false` is the intended escape hatch when a callback is set in `Retriable.configure` and a specific call wants to opt out. This behavior is exercised by `spec/retriable_spec.rb:112-132` but is not documented anywhere, so users discover it only by reading specs or source.

## Test Plan
- [x] bundle exec rspec (115 examples, 0 failures) — no code changes, purely additive docs

## Notes
- No code or behavior change.
- No version bump; folded under the unreleased 3.6.1 CHANGELOG entry.