### PR TITLE
Validate with_override contexts shape

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 3.6.1
 
 - Fix: Validate the `on:` option before retrying. Previously, passing a non-`Exception` value such as `Object`, `Kernel`, or a plain `Module` (which appear in every `Exception`'s ancestor chain) would silently retry process-critical exceptions like `SystemExit` and `Interrupt`. The `on:` option now requires an `Exception` subclass, an array of them, or a hash whose keys are such classes and whose values are `nil`, a `Regexp`, or an array of `Regexp`s. Invalid shapes raise `ArgumentError` before the block runs.
+- Fix: Validate `with_override(contexts:)` shape before applying overrides. `contexts` may be `nil` or a hash, and each per-context override must be a hash.
 - Docs: Document that `on_retry: false` disables a callback set in `Retriable.configure` for a single call.
 
 ## 3.6.0

--- a/lib/retriable.rb
+++ b/lib/retriable.rb
@@ -166,16 +166,23 @@ module Retriable
       raise ArgumentError, "#{k} is not a valid option" unless Config::ATTRIBUTES.include?(k)
     end
 
-    contexts = opts[:contexts]
-    return unless contexts.is_a?(Hash)
+    return unless opts.key?(:contexts)
 
-    contexts.each_value do |context_options|
-      validate_context_override_options(context_options)
+    contexts = opts[:contexts]
+    return if contexts.nil?
+
+    raise ArgumentError, "contexts must be a Hash or nil, got #{contexts.inspect}" unless contexts.is_a?(Hash)
+
+    contexts.each do |context_key, context_options|
+      validate_context_override_options(context_key, context_options)
     end
   end
 
-  def validate_context_override_options(context_options)
-    return unless context_options.is_a?(Hash)
+  def validate_context_override_options(context_key, context_options)
+    unless context_options.is_a?(Hash)
+      raise ArgumentError,
+            "contexts[#{context_key.inspect}] must be a Hash, got #{context_options.inspect}"
+    end
 
     context_attributes = Config::ATTRIBUTES - [:contexts]
     context_options.each_key do |k|

--- a/spec/retriable_spec.rb
+++ b/spec/retriable_spec.rb
@@ -597,28 +597,14 @@ describe Retriable do
       expect(@tries).to eq(1)
     end
 
-    it "ignores non-hash override contexts values in with_context" do
-      described_class.configure do |c|
-        c.contexts[:api] = { tries: 1 }
-      end
-
-      described_class.with_override(contexts: 123) do
-        described_class.with_context(:api) { increment_tries }
-      end
-
-      expect(@tries).to eq(1)
+    it "raises ArgumentError on non-hash override contexts values" do
+      expect { described_class.with_override(contexts: 123) { :noop } }
+        .to raise_error(ArgumentError, /contexts must be a Hash or nil/)
     end
 
-    it "ignores non-hash per-context override values in with_context" do
-      described_class.configure do |c|
-        c.contexts[:api] = { tries: 2 }
-      end
-
-      described_class.with_override(contexts: { api: 123 }) do
-        expect { described_class.with_context(:api) { increment_tries_with_exception } }.to raise_error(StandardError)
-      end
-
-      expect(@tries).to eq(2)
+    it "raises ArgumentError on non-hash per-context override values" do
+      expect { described_class.with_override(contexts: { api: 123 }) { :noop } }
+        .to raise_error(ArgumentError, /contexts\[:api\] must be a Hash/)
     end
 
     it "shows merged context keys in with_context missing-context errors" do

--- a/spec/retriable_spec.rb
+++ b/spec/retriable_spec.rb
@@ -598,13 +598,19 @@ describe Retriable do
     end
 
     it "raises ArgumentError on non-hash override contexts values" do
-      expect { described_class.with_override(contexts: 123) { :noop } }
+      block_called = false
+
+      expect { described_class.with_override(contexts: 123) { block_called = true } }
         .to raise_error(ArgumentError, /contexts must be a Hash or nil/)
+      expect(block_called).to be(false)
     end
 
     it "raises ArgumentError on non-hash per-context override values" do
-      expect { described_class.with_override(contexts: { api: 123 }) { :noop } }
+      block_called = false
+
+      expect { described_class.with_override(contexts: { api: 123 }) { block_called = true } }
         .to raise_error(ArgumentError, /contexts\[:api\] must be a Hash/)
+      expect(block_called).to be(false)
     end
 
     it "shows merged context keys in with_context missing-context errors" do


### PR DESCRIPTION
## Summary
- Reject non-Hash with_override contexts values while continuing to allow nil
- Reject non-Hash per-context override values before the block runs
- Document the validation change in the unreleased 3.6.1 changelog

## Verification
- bundle exec rspec
- bundle exec rubocop lib/retriable.rb spec/retriable_spec.rb