### PR TITLE
Deprecate timeout option for 3.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # HEAD
 
+## 3.8.0
+
+### Deprecations
+
+- Deprecated the `timeout:` option ahead of its removal in Retriable 4.0. Non-nil timeout values supplied through `Retriable.configure`, `Retriable.retriable(...)`, or `Retriable.with_override(...)` now emit a deprecation warning while keeping the existing runtime behavior unchanged. Prefer library-native timeout settings, or wrap the retried block in `Timeout.timeout(...)` directly if you still need that behavior. See the README migration guidance for details.
+
 ## 3.7.0
 
 - Feature: Opt-in unbounded retries via `tries: Float::INFINITY`. Requires a finite `max_elapsed_time` as a safety bound and is incompatible with custom `intervals:`. Both invalid configurations raise `ArgumentError` from `Config#validate!`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Deprecations
 
-- Deprecated the `timeout:` option ahead of its removal in Retriable 4.0. Non-nil timeout values supplied through `Retriable.configure`, `Retriable.retriable(...)`, or `Retriable.with_override(...)` now emit a deprecation warning while keeping the existing runtime behavior unchanged. The warning is emitted at most once per process and respects `Gem::Deprecate.skip_during` for callers (and test suites) that need to silence it. Prefer library-native timeout settings, or wrap the retried block in `Timeout.timeout(...)` directly if you still need that behavior. See the README migration guidance for details.
+- Deprecated the `timeout:` option ahead of its removal in Retriable 4.0. Non-nil timeout values supplied through `Retriable.configure`, `Retriable.retriable(...)`, or `Retriable.with_override(...)` now emit a deprecation warning while keeping the existing runtime behavior unchanged. On Ruby 2.7+ the warning is emitted via `Kernel.warn(..., category: :deprecated)`, so callers can silence it through the standard Ruby controls (`Warning[:deprecated] = false`, `ruby -W:no-deprecated`, or a custom `Warning.warn`). To keep the notice from drowning busy applications, it is emitted at most once per process; suppression via `Warning[:deprecated]` leaves the warner armed for the next call that re-enables the category. Prefer library-native timeout settings, or wrap the retried block in `Timeout.timeout(...)` directly if you still need that behavior. See the README migration guidance for details.
 
 ## 3.7.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Deprecations
 
-- Deprecated the `timeout:` option ahead of its removal in Retriable 4.0. Non-nil timeout values supplied through `Retriable.configure`, `Retriable.retriable(...)`, or `Retriable.with_override(...)` now emit a deprecation warning while keeping the existing runtime behavior unchanged. Prefer library-native timeout settings, or wrap the retried block in `Timeout.timeout(...)` directly if you still need that behavior. See the README migration guidance for details.
+- Deprecated the `timeout:` option ahead of its removal in Retriable 4.0. Non-nil timeout values supplied through `Retriable.configure`, `Retriable.retriable(...)`, or `Retriable.with_override(...)` now emit a deprecation warning while keeping the existing runtime behavior unchanged. The warning is emitted at most once per process and respects `Gem::Deprecate.skip_during` for callers (and test suites) that need to silence it. Prefer library-native timeout settings, or wrap the retried block in `Timeout.timeout(...)` directly if you still need that behavior. See the README migration guidance for details.
 
 ## 3.7.0
 

--- a/README.md
+++ b/README.md
@@ -264,7 +264,7 @@ end
 
 Like the deprecated `timeout:` option, `Timeout.timeout(5)` inside the block is per-try — each retry gets a fresh 5-second budget. If you want an overall cap across all retries instead, prefer `max_elapsed_time:`.
 
-The deprecation warning is emitted at most once per process. If you need to silence it (for example, in tests), wrap the call site in `Gem::Deprecate.skip_during { ... }`.
+The deprecation warning is emitted under the `:deprecated` warning category and at most once per process. To silence it (for example, in tests), use the standard Ruby controls — set `Warning[:deprecated] = false`, run with `ruby -W:no-deprecated`, or override `Warning.warn` to filter the message.
 
 If you need millisecond units of time for the sleep interval:
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Retriable is a simple DSL to retry failed code blocks with randomized [exponenti
   - [Configuration](#configuration)
   - [Override](#override)
   - [Example Usage](#example-usage)
+    - [Migrating off `timeout:`](#migrating-off-timeout)
   - [Custom Interval Array](#custom-interval-array)
   - [Turn off Exponential Backoff](#turn-off-exponential-backoff)
   - [Callbacks](#callbacks)
@@ -115,7 +116,7 @@ Here are the available options, in some vague order of relevance to most common 
 | **`multiplier`**       | `1.5`             | Each successive interval grows by this factor. A multipler of 1.5 means the next interval will be 1.5x the current interval.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
 | **`rand_factor`**      | `0.5`             | The percentage to randomize the next retry interval time. The next interval calculation is `randomized_interval = retry_interval * (random value in range [1 - randomization_factor, 1 + randomization_factor])`                                                                                                                                                                                                                                                                                                                                                                                                      |
 | **`intervals`**        | `nil`             | Skip generated intervals and provide your own array of intervals in seconds. [Read more](#custom-interval-array).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
-| **`timeout`**          | `nil`             | Number of seconds to allow the code block to run before raising a `Timeout::Error` inside each try. `nil` means the code block can run forever without raising error. The implementation uses `Timeout::timeout`, which may be [unsafe](https://jvns.ca/blog/2015/11/27/why-rubys-timeout-is-dangerous-and-thread-dot-raise-is-terrifying/) [and](http://blog.headius.com/2008/02/ruby-threadraise-threadkill-timeoutrb.html) [even](https://adamhooper.medium.com/in-ruby-dont-use-timeout-77d9d4e5a001) [dangerous](https://www.mikeperham.com/2015/05/08/timeout-rubys-most-dangerous-api/). Proceed with caution. |
+| **`timeout`**          | `nil`             | Deprecated in 3.8.0 and removed in 4.0. Number of seconds to allow the code block to run before raising a `Timeout::Error` inside each try. `nil` means the code block can run forever without raising error. Non-nil values emit a deprecation warning. See [Migrating off `timeout:`](#migrating-off-timeout).                                                                                                                                                                                                                                              |
 
 Timing options are validated before retrying. `tries` must be a positive integer when Retriable generates intervals, or `Float::INFINITY` for unbounded retries. `base_interval`, `max_interval`, `multiplier`, `max_elapsed_time`, and `timeout` must be non-negative numbers, with `max_elapsed_time` and `timeout` also accepting `nil`. `rand_factor` must be a number from `0` through `1`. If provided, `intervals` must be an array of non-negative numbers; because it replaces generated intervals, it also overrides `tries`, `base_interval`, `max_interval`, `rand_factor`, and `multiplier` validation. `intervals` cannot be combined with `tries: Float::INFINITY`.
 
@@ -243,20 +244,28 @@ Retriable.retriable(on: {
 end
 ```
 
-You can also specify a timeout if you want the code block to only try for X amount of seconds. This timeout is per try.
+#### Migrating off `timeout:`
 
-The implementation uses `Timeout::timeout`, which may be [unsafe](https://jvns.ca/blog/2015/11/27/why-rubys-timeout-is-dangerous-and-thread-dot-raise-is-terrifying/) [and](http://blog.headius.com/2008/02/ruby-threadraise-threadkill-timeoutrb.html) [even](https://adamhooper.medium.com/in-ruby-dont-use-timeout-77d9d4e5a001) [dangerous](https://www.mikeperham.com/2015/05/08/timeout-rubys-most-dangerous-api/). You can use this option, but you need to be very careful because the code in the block, including libraries or other code it calls, could be interrupted by the timeout at any line. You must ensure you have the right rescue logic and guards in place ([Thread.handle_interrupt](https://www.rubydoc.info/stdlib/core/Thread.handle_interrupt)) to handle that possible behavior. If that's not possible, the recommendation is that you're better off impelenting your own timeout methods depending on what your code is doing than use this feature.
+The `timeout:` option is deprecated in Retriable 3.8.0 and will be removed in Retriable 4.0. It still works in 3.x, but any non-nil value supplied through `Retriable.configure`, `Retriable.retriable(...)`, or `Retriable.with_override(...)` emits a deprecation warning. In Retriable 4.0, passing `timeout:` will raise `ArgumentError` because it will no longer be a valid option.
+
+`timeout:` is deprecated because it is a thin wrapper around `Timeout.timeout`, which may be [unsafe](https://jvns.ca/blog/2015/11/27/why-rubys-timeout-is-dangerous-and-thread-dot-raise-is-terrifying/) [and](http://blog.headius.com/2008/02/ruby-threadraise-threadkill-timeoutrb.html) [even](https://adamhooper.medium.com/in-ruby-dont-use-timeout-77d9d4e5a001) [dangerous](https://www.mikeperham.com/2015/05/08/timeout-rubys-most-dangerous-api/). It can interrupt the retried block at any line, including inside libraries that are not interrupt-safe.
+
+Prefer timeout settings from the library you are calling, such as `Net::HTTP#read_timeout`, `Net::HTTP#open_timeout`, or Faraday's request timeout options. If you still need `Timeout.timeout`, wrap the retried block explicitly so the risk is visible at the call site:
 
 ```ruby
-Retriable.retriable(timeout: 60) do
-  # code here...
+require "timeout"
+
+Retriable.retriable(on: Timeout::Error, tries: 3) do
+  Timeout.timeout(5) do
+    # code here...
+  end
 end
 ```
 
-If you need millisecond units of time for the sleep or the timeout:
+If you need millisecond units of time for the sleep interval:
 
 ```ruby
-Retriable.retriable(base_interval: (200 / 1000.0), timeout: (500 / 1000.0)) do
+Retriable.retriable(base_interval: (200 / 1000.0)) do
   # code here...
 end
 ```

--- a/README.md
+++ b/README.md
@@ -262,6 +262,10 @@ Retriable.retriable(on: Timeout::Error, tries: 3) do
 end
 ```
 
+Like the deprecated `timeout:` option, `Timeout.timeout(5)` inside the block is per-try — each retry gets a fresh 5-second budget. If you want an overall cap across all retries instead, prefer `max_elapsed_time:`.
+
+The deprecation warning is emitted at most once per process. If you need to silence it (for example, in tests), wrap the call site in `Gem::Deprecate.skip_during { ... }`.
+
 If you need millisecond units of time for the sleep interval:
 
 ```ruby

--- a/lib/retriable.rb
+++ b/lib/retriable.rb
@@ -56,15 +56,14 @@ module Retriable
 
   def retriable(opts = {}, &block)
     override_config = current_override
-    uses_config_singleton = opts.empty? && !override_config
-    local_config = if uses_config_singleton
+    local_config = if opts.empty? && !override_config
                      config
                    else
                      Config.new(apply_override_options(config.to_h.merge(opts), override_config))
                    end
 
     # Config is mutable through `configure`, so validate again immediately before use.
-    local_config.validate! if uses_config_singleton
+    local_config.validate!
 
     plan = retry_plan(local_config)
     timeout = local_config.timeout

--- a/lib/retriable.rb
+++ b/lib/retriable.rb
@@ -56,14 +56,15 @@ module Retriable
 
   def retriable(opts = {}, &block)
     override_config = current_override
-    local_config = if opts.empty? && !override_config
+    uses_config_singleton = opts.empty? && !override_config
+    local_config = if uses_config_singleton
                      config
                    else
                      Config.new(apply_override_options(config.to_h.merge(opts), override_config))
                    end
 
     # Config is mutable through `configure`, so validate again immediately before use.
-    local_config.validate!
+    local_config.validate! if uses_config_singleton
 
     plan = retry_plan(local_config)
     timeout = local_config.timeout

--- a/lib/retriable/config.rb
+++ b/lib/retriable/config.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "rubygems/deprecate"
-
 require_relative "exponential_backoff"
 require_relative "validation"
 
@@ -86,19 +84,41 @@ module Retriable
 
     private
 
-    # Emits the `timeout:` deprecation notice at most once per process, mirroring
-    # the convention used by Gem::Deprecate. Respects `Gem::Deprecate.skip` so
-    # callers (and tests) can suppress the warning via `Gem::Deprecate.skip_during`.
-    # We intentionally call `Kernel.warn` without `category: :deprecated` because
-    # `Warning[:deprecated]` defaults to false in Ruby 3.x, which would hide the
-    # notice from the very users we want to reach.
+    # Emits the `timeout:` deprecation notice at most once per process.
+    #
+    # On Rubies that support `Kernel#warn(category: :deprecated)` (2.7+), the
+    # notice is emitted under the `:deprecated` category, so callers can use the
+    # standard controls (`Warning[:deprecated] = false`, `-W:no-deprecated`,
+    # `Warning.warn` override) to silence it. On older Rubies the kwarg is not
+    # available and we fall back to plain `Kernel.warn`.
+    #
+    # When the warning is suppressed (either because `Warning[:deprecated]` is
+    # false or the runtime has otherwise muted the category), we deliberately
+    # leave the once-per-process flag unset so a future call with the category
+    # re-enabled still surfaces the notice.
     def warn_timeout_deprecation
       return if timeout.nil?
-      return if Gem::Deprecate.skip
       return if self.class.timeout_deprecation_warned
 
+      category_supported = deprecated_warning_category_supported?
+      return if category_supported && !deprecated_warnings_enabled?
+
       self.class.timeout_deprecation_warned = true
-      Kernel.warn(TIMEOUT_DEPRECATION_MESSAGE)
+      if category_supported
+        Kernel.warn(TIMEOUT_DEPRECATION_MESSAGE, category: :deprecated)
+      else
+        Kernel.warn(TIMEOUT_DEPRECATION_MESSAGE)
+      end
+    end
+
+    def deprecated_warning_category_supported?
+      Kernel.method(:warn).parameters.any? { |type, name| type == :key && name == :category }
+    end
+
+    def deprecated_warnings_enabled?
+      return true unless Warning.respond_to?(:[])
+
+      Warning[:deprecated]
     end
 
     def validate_backoff_options

--- a/lib/retriable/config.rb
+++ b/lib/retriable/config.rb
@@ -112,11 +112,11 @@ module Retriable
     end
 
     def deprecated_warning_category_supported?
-      Kernel.method(:warn).parameters.any? { |type, name| type == :key && name == :category }
+      defined?(Warning) && Kernel.method(:warn).parameters.any? { |type, name| type == :key && name == :category }
     end
 
     def deprecated_warnings_enabled?
-      return true unless Warning.respond_to?(:[])
+      return true unless defined?(Warning) && Warning.respond_to?(:[])
 
       Warning[:deprecated]
     end

--- a/lib/retriable/config.rb
+++ b/lib/retriable/config.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "rubygems/deprecate"
+
 require_relative "exponential_backoff"
 require_relative "validation"
 
@@ -18,12 +20,18 @@ module Retriable
       contexts
     ]).freeze
 
-    TIMEOUT_DEPRECATION_MESSAGE = "Retriable: the `timeout:` option is deprecated and will be removed in " \
+    TIMEOUT_DEPRECATION_MESSAGE = "NOTE: Retriable's `timeout:` option is deprecated and will be removed in " \
                                   "Retriable 4.0. It is a thin wrapper around `Timeout.timeout`, which " \
                                   "can interrupt execution at arbitrary lines and corrupt internal state " \
                                   "in libraries that are not interrupt-safe. Prefer your library's native " \
                                   "timeout, or wrap your block in `Timeout.timeout(...)` yourself."
     private_constant :TIMEOUT_DEPRECATION_MESSAGE
+
+    @timeout_deprecation_warned = false
+
+    class << self
+      attr_accessor :timeout_deprecation_warned
+    end
 
     attr_accessor(*ATTRIBUTES)
 
@@ -78,21 +86,19 @@ module Retriable
 
     private
 
+    # Emits the `timeout:` deprecation notice at most once per process, mirroring
+    # the convention used by Gem::Deprecate. Respects `Gem::Deprecate.skip` so
+    # callers (and tests) can suppress the warning via `Gem::Deprecate.skip_during`.
+    # We intentionally call `Kernel.warn` without `category: :deprecated` because
+    # `Warning[:deprecated]` defaults to false in Ruby 3.x, which would hide the
+    # notice from the very users we want to reach.
     def warn_timeout_deprecation
       return if timeout.nil?
+      return if Gem::Deprecate.skip
+      return if self.class.timeout_deprecation_warned
 
-      if deprecated_warning_category_enabled?
-        Kernel.warn(TIMEOUT_DEPRECATION_MESSAGE, category: :deprecated)
-      else
-        Kernel.warn(TIMEOUT_DEPRECATION_MESSAGE)
-      end
-    end
-
-    def deprecated_warning_category_enabled?
-      return false unless Kernel.method(:warn).parameters.any? { |type, name| type == :key && name == :category }
-      return false unless Warning.respond_to?(:[])
-
-      Warning[:deprecated]
+      self.class.timeout_deprecation_warned = true
+      Kernel.warn(TIMEOUT_DEPRECATION_MESSAGE)
     end
 
     def validate_backoff_options

--- a/lib/retriable/config.rb
+++ b/lib/retriable/config.rb
@@ -18,6 +18,13 @@ module Retriable
       contexts
     ]).freeze
 
+    TIMEOUT_DEPRECATION_MESSAGE = "Retriable: the `timeout:` option is deprecated and will be removed in " \
+                                  "Retriable 4.0. It is a thin wrapper around `Timeout.timeout`, which " \
+                                  "can interrupt execution at arbitrary lines and corrupt internal state " \
+                                  "in libraries that are not interrupt-safe. Prefer your library's native " \
+                                  "timeout, or wrap your block in `Timeout.timeout(...)` yourself."
+    private_constant :TIMEOUT_DEPRECATION_MESSAGE
+
     attr_accessor(*ATTRIBUTES)
 
     def initialize(opts = {})
@@ -53,6 +60,7 @@ module Retriable
     end
 
     def validate!
+      warn_timeout_deprecation
       validate_optional_non_negative_number(:timeout, timeout)
       validate_on(on)
       validate_intervals
@@ -69,6 +77,23 @@ module Retriable
     end
 
     private
+
+    def warn_timeout_deprecation
+      return if timeout.nil?
+
+      if deprecated_warning_category_enabled?
+        Kernel.warn(TIMEOUT_DEPRECATION_MESSAGE, category: :deprecated)
+      else
+        Kernel.warn(TIMEOUT_DEPRECATION_MESSAGE)
+      end
+    end
+
+    def deprecated_warning_category_enabled?
+      return false unless Kernel.method(:warn).parameters.any? { |type, name| type == :key && name == :category }
+      return false unless Warning.respond_to?(:[])
+
+      Warning[:deprecated]
+    end
 
     def validate_backoff_options
       validate_non_negative_number(:base_interval, base_interval)

--- a/lib/retriable/version.rb
+++ b/lib/retriable/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Retriable
-  VERSION = "3.7.0"
+  VERSION = "3.8.0"
 end

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "stringio"
+
 describe Retriable::Config do
   let(:default_config) { described_class.new }
 
@@ -90,6 +92,43 @@ describe Retriable::Config do
       expect do
         described_class.new
       end.not_to output.to_stderr
+    end
+
+    it "warns at most once per process" do
+      original_stderr = $stderr
+      stderr = StringIO.new
+      begin
+        $stderr = stderr
+
+        described_class.new(timeout: 5)
+        described_class.new(timeout: 5)
+
+        config = described_class.new
+        config.timeout = 5
+        config.validate!
+      ensure
+        $stderr = original_stderr
+      end
+
+      expect(stderr.string.scan("timeout:` option is deprecated").size).to eq(1)
+    end
+
+    it "is silenced by Gem::Deprecate.skip_during" do
+      expect do
+        Gem::Deprecate.skip_during do
+          described_class.new(timeout: 5)
+        end
+      end.not_to output.to_stderr
+    end
+
+    it "remains armed after Gem::Deprecate.skip_during so a later call still warns" do
+      Gem::Deprecate.skip_during do
+        described_class.new(timeout: 5)
+      end
+
+      expect do
+        described_class.new(timeout: 5)
+      end.to output(/timeout.*deprecated.*Retriable 4\.0/i).to_stderr
     end
   end
 

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -113,17 +113,39 @@ describe Retriable::Config do
       expect(stderr.string.scan("timeout:` option is deprecated").size).to eq(1)
     end
 
-    it "is silenced by Gem::Deprecate.skip_during" do
-      expect do
-        Gem::Deprecate.skip_during do
-          described_class.new(timeout: 5)
-        end
-      end.not_to output.to_stderr
+    it "emits the warning under the :deprecated category when supported", if: WARN_CATEGORY_SUPPORTED do
+      captured = []
+      allow(Warning).to receive(:warn) do |message, category: nil|
+        captured << [message, category]
+      end
+
+      described_class.new(timeout: 5)
+
+      expect(captured.size).to eq(1)
+      message, category = captured.first
+      expect(message).to match(/timeout.*deprecated.*Retriable 4\.0/i)
+      expect(category).to eq(:deprecated)
     end
 
-    it "remains armed after Gem::Deprecate.skip_during so a later call still warns" do
-      Gem::Deprecate.skip_during do
+    it "is silenced by Warning[:deprecated] = false", if: WARN_CATEGORY_SUPPORTED do
+      original = Warning[:deprecated]
+      begin
+        Warning[:deprecated] = false
+        expect do
+          described_class.new(timeout: 5)
+        end.not_to output.to_stderr
+      ensure
+        Warning[:deprecated] = original
+      end
+    end
+
+    it "remains armed when silenced via Warning[:deprecated]", if: WARN_CATEGORY_SUPPORTED do
+      original = Warning[:deprecated]
+      begin
+        Warning[:deprecated] = false
         described_class.new(timeout: 5)
+      ensure
+        Warning[:deprecated] = original
       end
 
       expect do

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -59,7 +59,9 @@ describe Retriable::Config do
 
   it "raises errors on invalid timing configuration" do
     expect { described_class.new(rand_factor: 1.1) }.to raise_error(ArgumentError, /rand_factor/)
-    expect { described_class.new(timeout: -1) }.to raise_error(ArgumentError, /timeout/)
+    expect do
+      expect { described_class.new(timeout: -1) }.to raise_error(ArgumentError, /timeout/)
+    end.to output(/timeout.*deprecated.*Retriable 4\.0/i).to_stderr
   end
 
   context "timeout deprecation" do

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -62,6 +62,35 @@ describe Retriable::Config do
     expect { described_class.new(timeout: -1) }.to raise_error(ArgumentError, /timeout/)
   end
 
+  context "timeout deprecation" do
+    it "warns when timeout is configured" do
+      expect do
+        described_class.new(timeout: 5)
+      end.to output(/timeout.*deprecated.*Retriable 4\.0/i).to_stderr
+    end
+
+    it "warns when timeout is set before validation" do
+      config = described_class.new
+      config.timeout = 5
+
+      expect do
+        config.validate!
+      end.to output(/timeout.*deprecated.*Retriable 4\.0/i).to_stderr
+    end
+
+    it "does not warn when timeout is nil" do
+      expect do
+        described_class.new(timeout: nil)
+      end.not_to output.to_stderr
+    end
+
+    it "does not warn when timeout is omitted" do
+      expect do
+        described_class.new
+      end.not_to output.to_stderr
+    end
+  end
+
   it "raises errors when intervals is not an array" do
     expect { described_class.new(intervals: "1") }.to raise_error(ArgumentError, /intervals must be an Array/)
   end

--- a/spec/retriable_spec.rb
+++ b/spec/retriable_spec.rb
@@ -201,10 +201,14 @@ describe Retriable do
       end
 
       it "keeps applying timeout while deprecated" do
-        Gem::Deprecate.skip_during do
+        original_stderr = $stderr
+        begin
+          $stderr = StringIO.new
           expect do
             described_class.retriable(timeout: 0.05, tries: 1) { sleep(0.5) }
           end.to raise_error(Timeout::Error)
+        ensure
+          $stderr = original_stderr
         end
       end
 
@@ -230,12 +234,16 @@ describe Retriable do
         end
       end
 
-      it "is silenced by Gem::Deprecate.skip_during" do
-        expect do
-          Gem::Deprecate.skip_during do
+      it "is silenced by Warning[:deprecated] = false", if: WARN_CATEGORY_SUPPORTED do
+        original = Warning[:deprecated]
+        begin
+          Warning[:deprecated] = false
+          expect do
             described_class.retriable(timeout: 5) { :noop }
-          end
-        end.not_to output.to_stderr
+          end.not_to output.to_stderr
+        ensure
+          Warning[:deprecated] = original
+        end
       end
 
       it "does not warn when timeout is absent" do

--- a/spec/retriable_spec.rb
+++ b/spec/retriable_spec.rb
@@ -178,12 +178,14 @@ describe Retriable do
     end
 
     context "timeout: deprecation" do
-      it "warns once when timeout is passed to retriable" do
+      it "warns at most once per process across repeated retriable calls" do
         original_stderr = $stderr
         stderr = StringIO.new
         begin
           $stderr = stderr
 
+          described_class.retriable(timeout: 5) { :noop }
+          described_class.retriable(timeout: 5) { :noop }
           described_class.retriable(timeout: 5) { :noop }
 
           expect(stderr.string.scan("timeout:` option is deprecated").size).to eq(1)
@@ -199,15 +201,10 @@ describe Retriable do
       end
 
       it "keeps applying timeout while deprecated" do
-        original_stderr = $stderr
-        begin
-          $stderr = StringIO.new
-
+        Gem::Deprecate.skip_during do
           expect do
             described_class.retriable(timeout: 0.05, tries: 1) { sleep(0.5) }
           end.to raise_error(Timeout::Error)
-        ensure
-          $stderr = original_stderr
         end
       end
 
@@ -231,6 +228,14 @@ describe Retriable do
             original_config.to_h.each { |key, value| config.public_send("#{key}=", value) }
           end
         end
+      end
+
+      it "is silenced by Gem::Deprecate.skip_during" do
+        expect do
+          Gem::Deprecate.skip_during do
+            described_class.retriable(timeout: 5) { :noop }
+          end
+        end.not_to output.to_stderr
       end
 
       it "does not warn when timeout is absent" do

--- a/spec/retriable_spec.rb
+++ b/spec/retriable_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "rbconfig"
+require "stringio"
 
 describe Retriable do
   let(:time_table_handler) do
@@ -170,6 +171,52 @@ describe Retriable do
 
     it "will timeout after 1 second" do
       expect { described_class.retriable(timeout: 1) { sleep(1.1) } }.to raise_error(Timeout::Error)
+    end
+
+    context "timeout: deprecation" do
+      it "warns when timeout is passed to retriable" do
+        expect do
+          described_class.retriable(timeout: 5) { :noop }
+        end.to output(/timeout.*deprecated.*Retriable 4\.0/i).to_stderr
+      end
+
+      it "keeps applying timeout while deprecated" do
+        original_stderr = $stderr
+        $stderr = StringIO.new
+
+        expect do
+          described_class.retriable(timeout: 0.05, tries: 1) { sleep(0.5) }
+        end.to raise_error(Timeout::Error)
+      ensure
+        $stderr = original_stderr
+      end
+
+      it "warns when timeout is supplied through with_override" do
+        expect do
+          described_class.with_override(timeout: 5) do
+            described_class.retriable { :noop }
+          end
+        end.to output(/timeout.*deprecated.*Retriable 4\.0/i).to_stderr
+      end
+
+      it "warns when timeout is supplied through configure" do
+        original_config = described_class.config
+
+        expect do
+          described_class.configure { |config| config.timeout = 5 }
+          described_class.retriable { :noop }
+        end.to output(/timeout.*deprecated.*Retriable 4\.0/i).to_stderr
+      ensure
+        described_class.configure do |config|
+          original_config.to_h.each { |key, value| config.public_send("#{key}=", value) }
+        end
+      end
+
+      it "does not warn when timeout is absent" do
+        expect do
+          described_class.retriable { :noop }
+        end.not_to output.to_stderr
+      end
     end
 
     it "applies a randomized exponential backoff to each try" do

--- a/spec/retriable_spec.rb
+++ b/spec/retriable_spec.rb
@@ -51,7 +51,9 @@ describe Retriable do
 
     it "raises a LocalJumpError if not given a block" do
       expect { described_class.retriable }.to raise_error(LocalJumpError)
-      expect { described_class.retriable(timeout: 2) }.to raise_error(LocalJumpError)
+      expect do
+        expect { described_class.retriable(timeout: 2) }.to raise_error(LocalJumpError)
+      end.to output(/timeout.*deprecated.*Retriable 4\.0/i).to_stderr
     end
 
     it "stops at first try if the block does not raise an exception" do
@@ -170,10 +172,26 @@ describe Retriable do
     end
 
     it "will timeout after 1 second" do
-      expect { described_class.retriable(timeout: 1) { sleep(1.1) } }.to raise_error(Timeout::Error)
+      expect do
+        expect { described_class.retriable(timeout: 1) { sleep(1.1) } }.to raise_error(Timeout::Error)
+      end.to output(/timeout.*deprecated.*Retriable 4\.0/i).to_stderr
     end
 
     context "timeout: deprecation" do
+      it "warns once when timeout is passed to retriable" do
+        original_stderr = $stderr
+        stderr = StringIO.new
+        begin
+          $stderr = stderr
+
+          described_class.retriable(timeout: 5) { :noop }
+
+          expect(stderr.string.scan("timeout:` option is deprecated").size).to eq(1)
+        ensure
+          $stderr = original_stderr
+        end
+      end
+
       it "warns when timeout is passed to retriable" do
         expect do
           described_class.retriable(timeout: 5) { :noop }
@@ -182,13 +200,15 @@ describe Retriable do
 
       it "keeps applying timeout while deprecated" do
         original_stderr = $stderr
-        $stderr = StringIO.new
+        begin
+          $stderr = StringIO.new
 
-        expect do
-          described_class.retriable(timeout: 0.05, tries: 1) { sleep(0.5) }
-        end.to raise_error(Timeout::Error)
-      ensure
-        $stderr = original_stderr
+          expect do
+            described_class.retriable(timeout: 0.05, tries: 1) { sleep(0.5) }
+          end.to raise_error(Timeout::Error)
+        ensure
+          $stderr = original_stderr
+        end
       end
 
       it "warns when timeout is supplied through with_override" do
@@ -201,14 +221,15 @@ describe Retriable do
 
       it "warns when timeout is supplied through configure" do
         original_config = described_class.config
-
-        expect do
-          described_class.configure { |config| config.timeout = 5 }
-          described_class.retriable { :noop }
-        end.to output(/timeout.*deprecated.*Retriable 4\.0/i).to_stderr
-      ensure
-        described_class.configure do |config|
-          original_config.to_h.each { |key, value| config.public_send("#{key}=", value) }
+        begin
+          expect do
+            described_class.configure { |config| config.timeout = 5 }
+            described_class.retriable { :noop }
+          end.to output(/timeout.*deprecated.*Retriable 4\.0/i).to_stderr
+        ensure
+          described_class.configure do |config|
+            original_config.to_h.each { |key, value| config.public_send("#{key}=", value) }
+          end
         end
       end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,5 +10,6 @@ require_relative "support/exceptions"
 RSpec.configure do |config|
   config.before(:each) do
     srand(0)
+    Retriable::Config.timeout_deprecation_warned = false
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,9 +7,20 @@ require "pry"
 require_relative "../lib/retriable"
 require_relative "support/exceptions"
 
+# Make Retriable's deprecation notices observable to RSpec's
+# `output().to_stderr` matcher. On Ruby 3.0+ the `:deprecated` warning category
+# is suppressed by default, which would hide the notices we want to assert on.
+Warning[:deprecated] = true if Warning.respond_to?(:[])
+
+# Used by deprecation specs that only make sense on Rubies where `Kernel#warn`
+# supports the `category:` keyword (added in Ruby 2.7).
+WARN_CATEGORY_SUPPORTED = Warning.respond_to?(:[]) &&
+                          Kernel.method(:warn).parameters.include?(%i[key category])
+
 RSpec.configure do |config|
   config.before(:each) do
     srand(0)
     Retriable::Config.timeout_deprecation_warned = false
+    Warning[:deprecated] = true if Warning.respond_to?(:[])
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,17 +10,18 @@ require_relative "support/exceptions"
 # Make Retriable's deprecation notices observable to RSpec's
 # `output().to_stderr` matcher. On Ruby 3.0+ the `:deprecated` warning category
 # is suppressed by default, which would hide the notices we want to assert on.
-Warning[:deprecated] = true if Warning.respond_to?(:[])
+WARNING_DEPRECATION_SUPPORTED = defined?(Warning) && Warning.respond_to?(:[])
+Warning[:deprecated] = true if WARNING_DEPRECATION_SUPPORTED
 
 # Used by deprecation specs that only make sense on Rubies where `Kernel#warn`
 # supports the `category:` keyword (added in Ruby 2.7).
-WARN_CATEGORY_SUPPORTED = Warning.respond_to?(:[]) &&
+WARN_CATEGORY_SUPPORTED = WARNING_DEPRECATION_SUPPORTED &&
                           Kernel.method(:warn).parameters.include?(%i[key category])
 
 RSpec.configure do |config|
   config.before(:each) do
     srand(0)
     Retriable::Config.timeout_deprecation_warned = false
-    Warning[:deprecated] = true if Warning.respond_to?(:[])
+    Warning[:deprecated] = true if WARNING_DEPRECATION_SUPPORTED
   end
 end


### PR DESCRIPTION
## Summary
- Deprecates non-nil `timeout:` usage while preserving existing 3.x runtime behavior. Related: https://github.com/kamui/retriable/issues/96
- Adds coverage for `Config`, `Retriable.retriable`, `with_override`, and configured timeout warnings, including avoiding duplicate warnings.
- Bumps the gem to 3.8.0 and documents the migration path before Retriable 4.0 removes `timeout:`.

## Test Plan
- [x] `bundle exec rspec` (`139 examples, 0 failures`)
- [x] `bundle exec rubocop` (same 5 pre-existing gemspec offenses as baseline; no new offenses)
- [x] `bundle exec ruby -Ilib -r retriable -e 'Retriable.retriable(timeout: 1) { :ok }'`
- [x] `bundle exec ruby -Ilib -r retriable -e 'Retriable.retriable { :ok }'`
- [x] `gem build retriable.gemspec && rm retriable-3.8.0.gem`