### PR TITLE
Finish Ruby 3.2 tooling for 4.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,6 +14,10 @@ jobs:
   ci:
     # The type of runner that the job will run on
     runs-on: ${{ matrix.os }}
+    # Ruby 4.0 is still in preview. Treat its results as informational so a
+    # preview-only regression doesn't block merges. Drop this gate (or update
+    # the version literal) once Ruby 4.0 is released and we treat it as
+    # required.
     continue-on-error: ${{ matrix.ruby == '4.0' }}
     strategy:
       matrix:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [main, 4.x]
+    branches: [main]
   pull_request:
-    branches: [main, 4.x]
+    branches: [main]
     types: [opened, synchronize, reopened]
 
 permissions:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches: [main, 4.x]
   pull_request:
-    branches: [main]
+    branches: [main, 4.x]
     types: [opened, synchronize, reopened]
 
 permissions:
@@ -14,13 +14,12 @@ jobs:
   ci:
     # The type of runner that the job will run on
     runs-on: ${{ matrix.os }}
+    continue-on-error: ${{ matrix.ruby == '4.0' }}
     strategy:
       matrix:
         os: [ubuntu-24.04]
         ruby:
           [
-            "3.0",
-            "3.1",
             "3.2",
             "3.3",
             "3.4",
@@ -45,3 +44,18 @@ jobs:
 
       - name: Run rspec
         run: bundle exec rspec
+
+  lint:
+    runs-on: ubuntu-24.04
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Setup ruby
+        uses: ruby/setup-ruby@afeafc3d1ab54a631816aba4c914a0081c12ff2f # v1
+        with:
+          ruby-version: "3.3"
+          bundler-cache: true
+
+      - name: Run rubocop
+        run: bundle exec rubocop

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,6 @@
 AllCops:
   NewCops: enable
-  TargetRubyVersion: 3.0
+  TargetRubyVersion: 3.2
 
 Style/StringLiterals:
   EnforcedStyle: double_quotes
@@ -39,14 +39,4 @@ Metrics/AbcSize:
   Enabled: false
 
 Style/TrailingCommaInArrayLiteral:
-  Enabled: false
-
-# Deferred to a follow-up PR; out of scope for 4.0 timeout removal.
-Gemspec/DeprecatedAttributeAssignment:
-  Enabled: false
-
-Gemspec/DevelopmentDependencies:
-  Enabled: false
-
-Gemspec/RequireMFA:
   Enabled: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@
 ### Breaking changes
 
 - Removed `timeout:` option. The `timeout:` option has been removed from `Retriable.retriable`, `Retriable.configure`, and `Retriable.with_override`. It was a thin wrapper around Ruby's `Timeout.timeout`, which has well-documented safety issues: it interrupts execution at arbitrary lines and can corrupt internal state in libraries that are not interrupt-safe (mutexes, file handles, network sockets, allocator state). This was first raised against this gem in [#96](https://github.com/kamui/retriable/issues/96) in 2021; Retriable 3.8.0 deprecated the option, and 4.0 removes the footgun entirely. As a side effect, the historical bug where Retriable's own internal `Timeout::Error` was silently retried by default is no longer reachable, since Retriable no longer raises a timeout itself. User-raised `Timeout::Error` (for example, from a `Timeout.timeout` block you write inside the retried block) is still matched by the default `on: [StandardError]` because `Timeout::Error < RuntimeError < StandardError`. Passing `timeout:` to `Retriable.retriable` or `Retriable.with_override` now raises `ArgumentError`; setting `config.timeout` in `Retriable.configure` now raises `NoMethodError` because the configuration attribute has been removed. See the [4.0 migration section in the README](README.md#migration-from-3x-to-40) for replacement patterns.
-- Minimum Ruby version is now 3.0. Support for Ruby 2.x has been dropped. If you need Retriable on Ruby 2.x, stay on the 3.x line.
+- Minimum Ruby version is now 3.2. Support for Ruby 2.x, 3.0, and 3.1 has been dropped in Retriable 4.0. If you need Retriable on Ruby 2.3.0-3.2.x, the 3.8.x line (`~> 3.8`) remains available.
+- Internal implementation has been updated for Ruby 3.x by switching `Retriable.retriable`, `Retriable.with_context`, and the `Kernel` extension methods to anonymous block forwarding. Behavior is unchanged.
 
 ## 3.8.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 ### Features
 
 - Add `on_give_up` callback that runs when Retriable stops retrying after a rescued retriable exception. Receives `(exception, try, elapsed_time, next_interval, reason)`, where `reason` is `:tries_exhausted` or `:max_elapsed_time`. Does not fire for non-retriable exceptions or `retry_if` rejections. Pass `on_give_up: false` to suppress a configured handler for a single call.
+- Accept a `Set` of `Exception` classes as the `on:` option, in addition to a single class, an `Array`, or a `Hash`.
 
 ### Internal
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,14 @@
 
 - Removed `timeout:` option. The `timeout:` option has been removed from `Retriable.retriable`, `Retriable.configure`, and `Retriable.with_override`. It was a thin wrapper around Ruby's `Timeout.timeout`, which has well-documented safety issues: it interrupts execution at arbitrary lines and can corrupt internal state in libraries that are not interrupt-safe (mutexes, file handles, network sockets, allocator state). This was first raised against this gem in [#96](https://github.com/kamui/retriable/issues/96) in 2021; Retriable 3.8.0 deprecated the option, and 4.0 removes the footgun entirely. As a side effect, the historical bug where Retriable's own internal `Timeout::Error` was silently retried by default is no longer reachable, since Retriable no longer raises a timeout itself. User-raised `Timeout::Error` (for example, from a `Timeout.timeout` block you write inside the retried block) is still matched by the default `on: [StandardError]` because `Timeout::Error < RuntimeError < StandardError`. Passing `timeout:` to `Retriable.retriable` or `Retriable.with_override` now raises `ArgumentError`; setting `config.timeout` in `Retriable.configure` now raises `NoMethodError` because the configuration attribute has been removed. See the [4.0 migration section in the README](README.md#migration-from-3x-to-40) for replacement patterns.
 - Minimum Ruby version is now 3.2. Support for Ruby 2.x, 3.0, and 3.1 has been dropped in Retriable 4.0. If you need Retriable on Ruby 2.3.0-3.2.x, the 3.8.x line (`~> 3.8`) remains available.
-- Internal implementation has been updated for Ruby 3.x by switching `Retriable.retriable`, `Retriable.with_context`, and the `Kernel` extension methods to anonymous block forwarding. Behavior is unchanged.
 
 ### Features
 
 - Add `on_give_up` callback that runs when Retriable stops retrying after a rescued retriable exception. Receives `(exception, try, elapsed_time, next_interval, reason)`, where `reason` is `:tries_exhausted` or `:max_elapsed_time`. Does not fire for non-retriable exceptions or `retry_if` rejections. Pass `on_give_up: false` to suppress a configured handler for a single call.
+
+### Internal
+
+- Switched `Retriable.retriable`, `Retriable.with_context`, and the `Kernel` extension methods to Ruby 3.1+ anonymous block forwarding. No user-visible behavior change.
 
 ## 3.8.0
 

--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,8 @@ group :test do
 end
 
 group :development do
-  gem "rubocop"
+  gem "listen", "~> 3.1"
+  gem "rubocop", "~> 1.86"
 end
 
 group :development, :test do

--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ Timing options are validated before retrying. `tries` must be a positive integer
 **`:on`** Can take the form:
 
 - An `Exception` class (retry every exception of this type, including subclasses)
-- An `Array` of `Exception` classes (retry any exception of one of these types, including subclasses)
+- An `Array` or `Set` of `Exception` classes (retry any exception of one of these types, including subclasses)
 - A `Hash` where the keys are `Exception` classes and the values are one of:
   - `nil` (retry every exception of the key's type, including subclasses)
   - A single `Regexp` pattern (retries exceptions ONLY if their `message` matches the pattern)

--- a/README.md
+++ b/README.md
@@ -36,11 +36,11 @@ Ruby 3.2+
 
 If you need Ruby 2.3.0-3.2.x support, use the [3.8.x branch](https://github.com/kamui/retriable/tree/3.8.x) by specifying `~> 3.8` in your Gemfile.
 
-If you need ruby 2.0.0-2.2.x support, use the [3.1 branch](https://github.com/kamui/retriable/tree/3.1.x) by specifying `~3.1` in your Gemfile.
+If you need Ruby 2.0.0-2.2.x support, use the [3.1 branch](https://github.com/kamui/retriable/tree/3.1.x) by specifying `~3.1` in your Gemfile.
 
-If you need ruby 1.9.3 support, use the [2.x branch](https://github.com/kamui/retriable/tree/2.x) by specifying `~2.1` in your Gemfile.
+If you need Ruby 1.9.3 support, use the [2.x branch](https://github.com/kamui/retriable/tree/2.x) by specifying `~2.1` in your Gemfile.
 
-If you need ruby 1.8.x to 1.9.2 support, use the [1.x branch](https://github.com/kamui/retriable/tree/1.x) by specifying `~1.4` in your Gemfile.
+If you need Ruby 1.8.x to 1.9.2 support, use the [1.x branch](https://github.com/kamui/retriable/tree/1.x) by specifying `~1.4` in your Gemfile.
 
 ## Migration from 3.x to 4.0
 

--- a/README.md
+++ b/README.md
@@ -30,9 +30,9 @@ Retriable is a simple DSL to retry failed code blocks with randomized [exponenti
 
 ## Requirements
 
-Ruby 3.0+
+Ruby 3.2+
 
-If you need ruby 2.3.0-2.7.x support, use the [3.8.x branch](https://github.com/kamui/retriable/tree/3.8.x) by specifying `~> 3.8` in your Gemfile.
+If you need Ruby 2.3.0-3.2.x support, use the [3.8.x branch](https://github.com/kamui/retriable/tree/3.8.x) by specifying `~> 3.8` in your Gemfile.
 
 If you need ruby 2.0.0-2.2.x support, use the [3.1 branch](https://github.com/kamui/retriable/tree/3.1.x) by specifying `~3.1` in your Gemfile.
 
@@ -44,7 +44,7 @@ If you need ruby 1.8.x to 1.9.2 support, use the [1.x branch](https://github.com
 
 ### Ruby version
 
-Retriable 4.0 requires Ruby 3.0 or later. If you are on Ruby 2.x, stay on Retriable 3.x.
+Retriable 4.0 requires Ruby 3.2 or later. If you run Ruby 2.3.0-3.2.x and want to stay on the 3.x gem line, use Retriable 3.8.x by specifying `~> 3.8` in your Gemfile.
 
 ### `timeout:` option removed
 

--- a/lib/retriable.rb
+++ b/lib/retriable.rb
@@ -40,7 +40,7 @@ module Retriable
     end
   end
 
-  def with_context(context_key, options = {}, &block)
+  def with_context(context_key, options = {}, &)
     contexts = available_contexts
 
     if !contexts.key?(context_key)
@@ -50,10 +50,10 @@ module Retriable
 
     return unless block_given?
 
-    retriable(context_options_for(context_key, options), &block)
+    retriable(context_options_for(context_key, options), &)
   end
 
-  def retriable(opts = {}, &block)
+  def retriable(opts = {}, &)
     override_config = current_override
     local_config = if opts.empty? && !override_config
                      config
@@ -80,7 +80,7 @@ module Retriable
       max_tries: plan.max_tries, interval_for: plan.interval_for,
       exception_list: exception_list, on: on, retry_if: retry_if, on_retry: on_retry,
       elapsed_time: elapsed_time, max_elapsed_time: max_elapsed_time,
-      sleep_disabled: sleep_disabled, &block
+      sleep_disabled: sleep_disabled, &
     )
   end
 

--- a/lib/retriable/core_ext/kernel.rb
+++ b/lib/retriable/core_ext/kernel.rb
@@ -3,11 +3,11 @@
 require_relative "../../retriable"
 
 module Kernel
-  def retriable(opts = {}, &block)
-    Retriable.retriable(opts, &block)
+  def retriable(opts = {}, &)
+    Retriable.retriable(opts, &)
   end
 
-  def retriable_with_context(context_key, opts = {}, &block)
-    Retriable.with_context(context_key, opts, &block)
+  def retriable_with_context(context_key, opts = {}, &)
+    Retriable.with_context(context_key, opts, &)
   end
 end

--- a/lib/retriable/validation.rb
+++ b/lib/retriable/validation.rb
@@ -58,12 +58,12 @@ module Retriable
     # Regexp values explicitly.
     def validate_on(value)
       case value
-      when Hash
+      in Hash
         value.each do |klass, pattern|
           validate_on_class(klass)
           validate_on_hash_value(klass, pattern)
         end
-      when Array
+      in Array
         value.each { |klass| validate_on_class(klass) }
       else
         validate_on_class(value)

--- a/lib/retriable/validation.rb
+++ b/lib/retriable/validation.rb
@@ -46,7 +46,7 @@ module Retriable
 
     # Validates an `on:` value. Acceptable shapes:
     #   - a Class that descends from Exception
-    #   - an Array whose elements are Classes that descend from Exception
+    #   - an Array or Set whose elements are Classes that descend from Exception
     #   - a Hash whose keys are such Classes and whose values are nil,
     #     a Regexp, or an Array of Regexps
     #
@@ -63,7 +63,7 @@ module Retriable
           validate_on_class(klass)
           validate_on_hash_value(klass, pattern)
         end
-      in Array
+      in Array | Set
         value.each { |klass| validate_on_class(klass) }
       else
         validate_on_class(value)

--- a/retriable.gemspec
+++ b/retriable.gemspec
@@ -15,15 +15,10 @@ Gem::Specification.new do |spec|
                        "APIs/services or file system calls."
   spec.homepage      = "https://github.com/kamui/retriable"
   spec.license       = "MIT"
+  spec.metadata["rubygems_mfa_required"] = "true"
 
   spec.files         = `git ls-files -z`.split("\x0")
-  spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = ">= 3.0"
-
-  spec.add_development_dependency "bundler"
-  spec.add_development_dependency "rspec", "~> 3"
-
-  spec.add_development_dependency "listen", "~> 3.1"
+  spec.required_ruby_version = ">= 3.2"
 end

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -102,6 +102,15 @@ describe Retriable::Config do
       expect { described_class.new(on: [StandardError, RuntimeError]) }.not_to raise_error
     end
 
+    it "accepts a Set of Exception subclasses" do
+      expect { described_class.new(on: Set[StandardError, RuntimeError]) }.not_to raise_error
+    end
+
+    it "rejects a Set containing a non-Exception class" do
+      expect { described_class.new(on: Set[StandardError, Kernel]) }
+        .to raise_error(ArgumentError, /on must be an Exception class/)
+    end
+
     it "accepts a hash with nil pattern values" do
       expect { described_class.new(on: { StandardError => nil }) }.not_to raise_error
     end

--- a/spec/retriable_spec.rb
+++ b/spec/retriable_spec.rb
@@ -49,6 +49,28 @@ describe Retriable do
 
       expect(received_reason).to eq(:tries_exhausted)
     end
+
+    # These two specs lock in the anonymous block forwarding (`&`) semantics
+    # across both delegation layers: Kernel#retriable_with_context ->
+    # Retriable.with_context. If the `&` is dropped at either layer, the
+    # block is not forwarded and the inner `block_given?` check at
+    # lib/retriable.rb:51 short-circuits, causing the block to never run.
+    it "forwards a block through Kernel#retriable_with_context" do
+      require_relative "../lib/retriable/core_ext/kernel"
+      Retriable.configure { |c| c.contexts[:sql] = { tries: 1 } }
+
+      retriable_with_context(:sql) { increment_tries }
+
+      expect(@tries).to eq(1)
+    end
+
+    it "returns nil when Kernel#retriable_with_context is called without a block" do
+      require_relative "../lib/retriable/core_ext/kernel"
+      Retriable.configure { |c| c.contexts[:sql] = { tries: 1 } }
+
+      expect(retriable_with_context(:sql)).to be_nil
+      expect(@tries).to eq(0)
+    end
   end
 
   context "#retriable" do
@@ -432,6 +454,19 @@ describe Retriable do
     context "with an array :on parameter" do
       it "handles both kinds of exceptions" do
         described_class.retriable(on: [StandardError, NonStandardError]) do
+          increment_tries
+
+          raise StandardError if @tries == 1
+          raise NonStandardError if @tries == 2
+        end
+
+        expect(@tries).to eq(3)
+      end
+    end
+
+    context "with a Set :on parameter" do
+      it "retries each exception class in the Set" do
+        described_class.retriable(on: Set[StandardError, NonStandardError]) do
           increment_tries
 
           raise StandardError if @tries == 1


### PR DESCRIPTION
## Summary
- Raise the unreleased 4.0 Ruby floor and RuboCop target to Ruby 3.2
- Close deferred gemspec/RuboCop debt and add a dedicated lint CI job
- Update 4.0 docs/changelog, including the Ruby 2.3.0-3.2.x pointer to `~> 3.8`
- Apply Ruby 3 anonymous block forwarding and `case/in` cleanup without behavior changes
- Remove the retired `4.x` workflow branch filter now that it has been renamed to `main`

## Test Plan
- [x] `bundle install`
- [x] `bundle exec rspec` (143 examples, 0 failures)
- [x] `bundle exec rubocop` (15 files, no offenses)
- [x] `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/main.yml"); puts "workflow YAML parses"'`\n- [x] Independent review: no findings; `gem build retriable.gemspec` also passed there\n\n## Notes\n- Draft PR targeting `main` as requested.\n- Ruby 4.0 remains in CI but is informational via `continue-on-error`.