### PR TITLE
Fix tries precedence over inherited intervals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # HEAD
 
+## 4.1.0
+
+### Bug fixes
+
+- A per-call or `with_context` `tries:` now clears an inherited `intervals:` from
+  global config or a context, matching the documented precedence. Previously
+  `Retriable.retriable(tries: 1)` was silently ignored when `intervals` was
+  configured, running `intervals.size + 1` times. Passing both `intervals:` and
+  `tries:` in the same call still lets `intervals:` win.
+
 ## 4.0.0
 
 **This is a major release with breaking changes. Please read carefully before upgrading.**

--- a/README.md
+++ b/README.md
@@ -206,6 +206,11 @@ end
 `#configure` sets defaults only. Per-call options passed to `Retriable.retriable` and
 `Retriable.with_context` still take precedence.
 
+When a higher-precedence layer sets `tries:` without `intervals:`, it clears any
+`intervals:` inherited from a lower layer (so `retriable(tries: 1)` runs once even
+if `intervals` was configured). Within a single call, passing `intervals:` still
+overrides `tries:`.
+
 ### Override
 
 `#with_override` is a block-scoped API for forcing retry options that should

--- a/lib/retriable.rb
+++ b/lib/retriable.rb
@@ -58,7 +58,7 @@ module Retriable
     local_config = if opts.empty? && !override_config
                      config
                    else
-                     Config.new(apply_override_options(config.to_h.merge(opts), override_config))
+                     Config.new(apply_override_options(merge_layer(config.to_h, opts), override_config))
                    end
 
     # Config is mutable through `configure`, so validate again immediately before use.
@@ -216,9 +216,17 @@ module Retriable
   def apply_override_options(options, overrides)
     return options unless overrides
 
-    options = options.merge(overrides)
-    options[:intervals] = nil if overrides.key?(:tries) && !overrides.key?(:intervals)
-    options
+    merge_layer(options, overrides)
+  end
+
+  # Merge a higher-precedence option layer onto a base layer. A higher layer
+  # that sets `tries` without `intervals` clears the base layer's inherited
+  # `intervals`, so a caller's `tries:` is never silently ignored. When the
+  # higher layer supplies its own `intervals`, those win (same-call override).
+  def merge_layer(base, higher)
+    merged = base.merge(higher)
+    merged[:intervals] = nil if higher.key?(:tries) && !higher.key?(:intervals)
+    merged
   end
 
   def available_contexts
@@ -228,7 +236,7 @@ module Retriable
   def context_options_for(context_key, options)
     context_options = config_contexts.fetch(context_key, {})
     context_options = {} unless context_options.is_a?(Hash)
-    context_options = context_options.merge(options)
+    context_options = merge_layer(context_options, options)
 
     override_context_options = override_contexts[context_key]
     return context_options unless override_context_options.is_a?(Hash)
@@ -262,6 +270,7 @@ module Retriable
     :retriable_exception?,
     :hash_exception_match?,
     :apply_override_options,
+    :merge_layer,
     :available_contexts,
     :context_options_for,
     :config_contexts,

--- a/lib/retriable/version.rb
+++ b/lib/retriable/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Retriable
-  VERSION = "4.0.0"
+  VERSION = "4.1.0"
 end

--- a/spec/retriable_spec.rb
+++ b/spec/retriable_spec.rb
@@ -760,6 +760,38 @@ describe Retriable do
     end
   end
 
+  context "#retriable tries/intervals precedence" do
+    it "lets a per-call tries clear globally configured intervals" do
+      described_class.configure { |c| c.intervals = [0.5, 1.0] }
+
+      expect do
+        described_class.retriable(tries: 1) { increment_tries_with_exception }
+      end.to raise_error(StandardError)
+
+      expect(@tries).to eq(1)
+    end
+
+    it "still lets per-call intervals win when both intervals and tries are given" do
+      expect do
+        described_class.retriable(intervals: [0.5, 1.0], tries: 1) { increment_tries_with_exception }
+      end.to raise_error(StandardError)
+
+      expect(@tries).to eq(3) # intervals.size + 1
+    end
+
+    it "lets a with_context tries clear context intervals" do
+      described_class.configure do |c|
+        c.contexts[:api] = { intervals: [0.5, 1.0] }
+      end
+
+      expect do
+        described_class.with_context(:api, tries: 1) { increment_tries_with_exception }
+      end.to raise_error(StandardError)
+
+      expect(@tries).to eq(1)
+    end
+  end
+
   context "#with_override" do
     it "takes precedence over both global config and local options" do
       described_class.configure { |c| c.tries = 2 }


### PR DESCRIPTION
## Summary
- Add regression coverage for per-call and context tries overriding inherited intervals
- Generalize option-layer merging so higher-precedence tries clears lower-precedence intervals unless intervals is supplied in the same layer
- Document the behavior and bump the gem version to 4.1.0

## Test Plan
- [x] bundle exec rspec --format progress
- [x] bundle exec rubocop