### PR TITLE
Validate callable options

### DIFF
--- a/lib/retriable/config.rb
+++ b/lib/retriable/config.rb
@@ -51,6 +51,9 @@ module Retriable
     end
 
     def validate!
+      validate_callable(:retry_if, retry_if)
+      validate_callable(:on_retry, on_retry)
+      validate_callable(:on_give_up, on_give_up)
       validate_on(on)
       validate_intervals
       if unbounded_tries?(tries)

--- a/lib/retriable/validation.rb
+++ b/lib/retriable/validation.rb
@@ -28,6 +28,13 @@ module Retriable
       validate_non_negative_number(name, value)
     end
 
+    def validate_callable(name, value)
+      return unless value # nil/false disable the callback
+      return if value.respond_to?(:call)
+
+      raise ArgumentError, "#{name} must respond to #call or be nil"
+    end
+
     def validate_rand_factor
       return if finite_number?(rand_factor) && rand_factor >= 0 && rand_factor <= 1
 

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -163,4 +163,21 @@ describe Retriable::Config do
         .to raise_error(ArgumentError, /on must be an Exception class/)
     end
   end
+
+  context "callable option validation" do
+    %i[retry_if on_retry on_give_up].each do |opt|
+      it "accepts a callable for #{opt}" do
+        expect { described_class.new(opt => ->(*) {}) }.not_to raise_error
+      end
+
+      it "accepts nil and false for #{opt}" do
+        expect { described_class.new(opt => nil) }.not_to raise_error
+        expect { described_class.new(opt => false) }.not_to raise_error
+      end
+
+      it "rejects a non-callable truthy value for #{opt}" do
+        expect { described_class.new(opt => 5) }.to raise_error(ArgumentError, /#{opt}.*#call/)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Validates `retry_if`/`on_retry`/`on_give_up` respond to `#call` (nil/false still disable the callback). Fails fast at configure/call time with a clear ArgumentError instead of a `NoMethodError` surfacing later on a retry path.

Addresses review Finding 2 (callable-option validation).