### PR TITLE
Add RBS signatures for the public API

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -62,6 +62,9 @@ jobs:
       - name: Run rubocop
         run: bundle exec rubocop
 
+      - name: Validate RBS
+        run: bundle exec rbs -I sig validate
+
   audit:
     runs-on: ubuntu-24.04
 

--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,7 @@ end
 group :development do
   gem "bundler-audit", "~> 0.9"
   gem "listen", "~> 3.1"
+  gem "rbs", "~> 3.0", platforms: :ruby
   gem "rubocop", "~> 1.86"
 end
 

--- a/sig/retriable.rbs
+++ b/sig/retriable.rbs
@@ -1,4 +1,32 @@
 module Retriable
   VERSION: String
-  # See the writing guide of rbs: https://github.com/ruby/rbs#guides
+  OVERRIDE_THREAD_KEY: Symbol
+
+  def self.configure: () { (Config) -> void } -> void
+  def self.config: () -> Config
+  def self.with_override: (Hash[Symbol, untyped] options) { () -> untyped } -> untyped
+  def self.with_context: (Symbol context_key, ?Hash[Symbol, untyped] options) ?{ (Integer) -> untyped } -> untyped
+  def self.retriable: (?Hash[Symbol, untyped] options) { (Integer) -> untyped } -> untyped
+
+  class Config
+    ATTRIBUTES: Array[Symbol]
+
+    attr_accessor tries: Numeric
+    attr_accessor base_interval: Numeric
+    attr_accessor max_interval: Numeric
+    attr_accessor rand_factor: Numeric
+    attr_accessor multiplier: Numeric
+    attr_accessor sleep_disabled: bool
+    attr_accessor max_elapsed_time: Numeric?
+    attr_accessor intervals: Array[Numeric]?
+    attr_accessor on: untyped
+    attr_accessor retry_if: untyped
+    attr_accessor on_retry: untyped
+    attr_accessor on_give_up: untyped
+    attr_accessor contexts: Hash[Symbol, untyped]
+
+    def initialize: (?Hash[Symbol, untyped] opts) -> void
+    def to_h: () -> Hash[Symbol, untyped]
+    def validate!: () -> void
+  end
 end


### PR DESCRIPTION
Replaces the VERSION-only `sig/retriable.rbs` stub with signatures for `retriable`/`configure`/`config`/`with_override`/`with_context` and `Config`. Polymorphic options (`on`, the callbacks) are typed `untyped` to keep the signature honest and low-maintenance. Adds a `bundle exec rbs -I sig validate` step to the lint CI job so the signatures don't rot.

Addresses review Finding 4.