### PR TITLE
Enforce coverage floor and add dependency audit

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -61,3 +61,18 @@ jobs:
 
       - name: Run rubocop
         run: bundle exec rubocop
+
+  audit:
+    runs-on: ubuntu-24.04
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Setup ruby
+        uses: ruby/setup-ruby@afeafc3d1ab54a631816aba4c914a0081c12ff2f # v1
+        with:
+          ruby-version: "3.3"
+          bundler-cache: true
+
+      - name: Run bundler-audit
+        run: bundle exec bundle-audit check --update

--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,7 @@ group :test do
 end
 
 group :development do
+  gem "bundler-audit", "~> 0.9"
   gem "listen", "~> 3.1"
   gem "rubocop", "~> 1.86"
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,9 @@
 # frozen_string_literal: true
 
 require "simplecov"
-SimpleCov.start
+SimpleCov.start do
+  minimum_coverage 95
+end
 
 require "pry"
 require_relative "../lib/retriable"


### PR DESCRIPTION
Two CI hardening changes (review Finding 7):

- Adds `SimpleCov.minimum_coverage 95` so coverage regressions fail the build (current coverage is 99.61%, leaving a safe margin).
- Adds a `bundle-audit` CI job (and the `bundler-audit` dev gem) to catch vulnerable locked dependencies, complementing Dependabot.

Note: the lockfile is gitignored, so CI resolves dependencies fresh; current resolution picks a `json` release patched against GHSA-3m6g-2423-7cp3.