### PR TITLE
Document on_retry next_interval: nil contract on give-up attempt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # HEAD
 
+### Docs
+
+- Document that `on_retry` receives `next_interval: nil` on the final rescued
+  attempt, when Retriable is about to give up because `tries` are exhausted.
+  `on_retry` still fires before `on_give_up` (unchanged behavior); the `nil`
+  contract is now called out in the `on_retry` documentation so handlers guard
+  arithmetic or logging on `next_interval`.
+
 ## 4.1.1
 
 ### Bug fixes

--- a/README.md
+++ b/README.md
@@ -367,6 +367,8 @@ Retriable.retriable(on_retry: do_this_on_each_retry) do
 end
 ```
 
+> **Note:** On the final rescued attempt — when Retriable is about to give up because `tries` are exhausted — `on_retry` still fires (before `on_give_up`; see below), but `next_interval` is **`nil`** because there is no next retry. Guard any handler that does arithmetic or formatting on `next_interval` (for example `next_interval&.*(1000)`, or `if next_interval`), and avoid unconditionally logging messages like `"retrying in #{next_interval}s"` since no retry is coming. This mirrors the `nil` contract documented for [`on_give_up`](#callbacks) below.
+
 #### Disabling a Configured Callback Per Call
 
 If `on_retry` is set in `Retriable.configure`, every call uses it by default. To opt a specific call out — for example, a critical call site that should not log on retry — pass `on_retry: false` or `on_retry: nil`.

--- a/lib/retriable.rb
+++ b/lib/retriable.rb
@@ -97,6 +97,9 @@ module Retriable
       rescue *exception_list => e
         raise unless retriable_exception?(e, on, exception_list, retry_if)
 
+        # On the final attempt `interval_for` returns nil (no next retry), and
+        # `on_retry` intentionally fires before the give-up check below, so it
+        # receives `interval: nil`. See the on_retry/on_give_up README contract.
         interval = interval_for.call(try - 1)
         call_on_retry(on_retry, e, try, elapsed_time.call, interval)
 


### PR DESCRIPTION
## Summary

On the final rescued attempt, `interval_for` returns `nil` (no next retry), and `on_retry` fires—before `on_give_up`—with that `nil` (lib/retriable.rb:100-101). This ordering is intentional and covered by specs (`on_retry` before `on_give_up`, and specs asserting `on_retry` receives `nil` on the final try). However, the `nil` contract was documented only for `on_give_up`, so an `on_retry` handler doing `interval * 1000` would crash, or logging "retrying in ${interval}s" would lie.

This is a **documentation-only, non-breaking** change. No retry behavior or callback ordering changes.

## Changes

- **README** `on_retry` section: prominent note that `next_interval` is `nil` on the final attempt when giving up, with guidance to guard arithmetic/logging, cross-referencing the existing `on_give_up` `nil` note.
- **CHANGELOG** `# HEAD`: `### Docs` entry.
- **lib/retriable.rb**: inline comment near the `on_retry` call explaining the intentional `nil`/ordering.

## Verification

- `bundle exec rspec` → 162 examples, 0 failures
- `bundle exec rubocop` → 15 files inspected, no offenses

## Out of scope

Suppressing the final `on_retry` call (firing only `on_give_up` on the last attempt) would be a breaking change requiring a major version bump and spec/contract updates; not done here per the chosen non-breaking direction.