### PR TITLE
Make Kernel core_ext methods private

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
   methods, so they leaked onto every object's public API and could be invoked
   with an explicit receiver (e.g. `"foo".retriable { ... }`). They remain
   callable in the documented receiver-less form.
+  ([#146](https://github.com/kamui/retriable/pull/146))
 
 ### Docs
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # HEAD
 
+### Bug fixes
+
+- The `Kernel` extension methods (`require "retriable/core_ext/kernel"`) are now
+  private, matching idiomatic `Kernel` helpers like `puts` and `rand`.
+  Previously `retriable` and `retriable_with_context` were public instance
+  methods, so they leaked onto every object's public API and could be invoked
+  with an explicit receiver (e.g. `"foo".retriable { ... }`). They remain
+  callable in the documented receiver-less form.
+
 ### Docs
 
 - Document that `on_retry` receives `next_interval: nil` on the final rescued

--- a/lib/retriable/core_ext/kernel.rb
+++ b/lib/retriable/core_ext/kernel.rb
@@ -10,4 +10,6 @@ module Kernel
   def retriable_with_context(context_key, opts = {}, &)
     Retriable.with_context(context_key, opts, &)
   end
+
+  private :retriable, :retriable_with_context
 end

--- a/spec/retriable_spec.rb
+++ b/spec/retriable_spec.rb
@@ -71,6 +71,15 @@ describe Retriable do
       expect(retriable_with_context(:sql)).to be_nil
       expect(@tries).to eq(0)
     end
+
+    it "is not callable with an explicit receiver" do
+      require_relative "../lib/retriable/core_ext/kernel"
+
+      expect { "foo".retriable { increment_tries } }
+        .to raise_error(NoMethodError, /private method/)
+      expect { "foo".retriable_with_context(:sql) { increment_tries } }
+        .to raise_error(NoMethodError, /private method/)
+    end
   end
 
   context "#retriable" do


### PR DESCRIPTION
## Problem

`lib/retriable/core_ext/kernel.rb` defined `retriable` and `retriable_with_context` as **public** instance methods on `Kernel`. Because every object includes `Kernel`, these leaked onto every object's public API — `"foo".retriable { ... }` worked and polluted the public surface of every object in a program that required `retriable/core_ext/kernel`.

Idiomatic `Kernel` extensions (`puts`, `rand`, `require`) are private, so they're only callable in receiver-less form.

## Change

Add `private :retriable, :retriable_with_context` to the `Kernel` reopening. The methods remain callable in the documented receiver-less form (`retriable { ... }`), but can no longer be invoked with an explicit receiver.

Chose `private :sym, :sym` over `module_function` because `module_function` would additionally define public `Kernel.retriable` / `Kernel.retriable_with_context` module methods — a new public API surface that isn't wanted here.

## Tests

- Added a regression spec asserting `"foo".retriable { ... }` and `"foo".retriable_with_context(:sql) { ... }` raise `NoMethodError` (`/private method/`).
- Existing specs already exercise the receiver-less form, confirming no behavior change for documented usage.
- Full suite: 163 examples, 0 failures. Rubocop clean.

No RBS or README changes needed — the Kernel extension isn't in `sig/`, and documented usage is already receiver-less.