### PR TITLE
fix: with_context raises ArgumentError without a block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@
   with an explicit receiver (e.g. `"foo".retriable { ... }`). They remain
   callable in the documented receiver-less form.
   ([#146](https://github.com/kamui/retriable/pull/146))
+- `Retriable.with_context` (and `Kernel#retriable_with_context`) now raises
+  `ArgumentError` when called without a block, matching `with_override`.
+  Previously a missing block was silently ignored: the call returned `nil` and
+  the intended block never ran, hiding a caller bug. Behavior change: code that
+  relied on the silent no-op will now raise.
 
 ### Docs
 

--- a/README.md
+++ b/README.md
@@ -473,6 +473,9 @@ Retriable.with_context(:mysql, tries: 30) do
 end
 ```
 
+`#with_context` requires a block and raises `ArgumentError` if called without
+one.
+
 ## Kernel Extension
 
 If you want to call `Retriable.retriable` without the `Retriable` module prefix and you don't mind extending `Kernel`,

--- a/lib/retriable.rb
+++ b/lib/retriable.rb
@@ -41,14 +41,14 @@ module Retriable
   end
 
   def with_context(context_key, options = {}, &)
+    raise ArgumentError, "with_context requires a block" unless block_given?
+
     contexts = available_contexts
 
     if !contexts.key?(context_key)
       raise ArgumentError,
             "#{context_key} not found in Retriable contexts (including overrides). Available contexts: #{contexts.keys}"
     end
-
-    return unless block_given?
 
     retriable(context_options_for(context_key, options), &)
   end

--- a/sig/retriable.rbs
+++ b/sig/retriable.rbs
@@ -5,7 +5,7 @@ module Retriable
   def self.configure: () { (Config) -> void } -> void
   def self.config: () -> Config
   def self.with_override: (Hash[Symbol, untyped] options) { () -> untyped } -> untyped
-  def self.with_context: (Symbol context_key, ?Hash[Symbol, untyped] options) ?{ (Integer) -> untyped } -> untyped
+  def self.with_context: (Symbol context_key, ?Hash[Symbol, untyped] options) { (Integer) -> untyped } -> untyped
   def self.retriable: (?Hash[Symbol, untyped] options) { (Integer) -> untyped } -> untyped
 
   class Config

--- a/spec/retriable_spec.rb
+++ b/spec/retriable_spec.rb
@@ -52,9 +52,9 @@ describe Retriable do
 
     # These two specs lock in the anonymous block forwarding (`&`) semantics
     # across both delegation layers: Kernel#retriable_with_context ->
-    # Retriable.with_context. If the `&` is dropped at either layer, the
-    # block is not forwarded and the inner `block_given?` check at
-    # lib/retriable.rb:51 short-circuits, causing the block to never run.
+    # Retriable.with_context. If the `&` is dropped at either layer, the block
+    # is not forwarded and the `block_given?` guard in with_context raises
+    # ArgumentError instead of running the block.
     it "forwards a block through Kernel#retriable_with_context" do
       require_relative "../lib/retriable/core_ext/kernel"
       Retriable.configure { |c| c.contexts[:sql] = { tries: 1 } }
@@ -64,11 +64,12 @@ describe Retriable do
       expect(@tries).to eq(1)
     end
 
-    it "returns nil when Kernel#retriable_with_context is called without a block" do
+    it "raises an ArgumentError when Kernel#retriable_with_context is called without a block" do
       require_relative "../lib/retriable/core_ext/kernel"
       Retriable.configure { |c| c.contexts[:sql] = { tries: 1 } }
 
-      expect(retriable_with_context(:sql)).to be_nil
+      expect { retriable_with_context(:sql) }
+        .to raise_error(ArgumentError, /with_context requires a block/)
       expect(@tries).to eq(0)
     end
 
@@ -1257,8 +1258,9 @@ describe Retriable do
       expect(@tries).to eq(1)
     end
 
-    it "returns nil when called without a block" do
-      expect(described_class.with_context(:sql)).to be_nil
+    it "raises an ArgumentError when called without a block" do
+      expect { described_class.with_context(:sql) }
+        .to raise_error(ArgumentError, /with_context requires a block/)
       expect(@tries).to eq(0)
     end
 


### PR DESCRIPTION
## Problem

`Retriable.with_context` (and `Kernel#retriable_with_context`) silently no-opped when called without a block. The old `return unless block_given?` at `lib/retriable.rb:51` meant `Retriable.with_context(:api)` validated the context key, then returned `nil` and **never ran the intended block**.

This hid a bug in caller code (a forgotten block) and was inconsistent with `with_override`, which already raises `ArgumentError` when called without a block.

## Fix

Add a `block_given?` guard at the top of `with_context` — before the context-key lookup, mirroring `with_override`:

```ruby
def with_context(context_key, options = {}, &)
  raise ArgumentError, "with_context requires a block" unless block_given?
  # ...
end
```

## Changes

- `lib/retriable.rb` — raise `ArgumentError, "with_context requires a block"` before context-key validation.
- `sig/retriable.rbs` — block is now required (`{ ... }` instead of `?{ ... }`).
- `spec/retriable_spec.rb` — flip the two specs that locked in the old no-op behavior to expect `ArgumentError`.
- `CHANGELOG.md` — bug-fix entry with explicit behavior-change note.
- `README.md` — note that `#with_context` requires a block.

`Kernel#retriable_with_context` delegates to `Retriable.with_context`, so it inherits the new behavior automatically.

## Behavior change

Code that relied on the silent no-op will now raise `ArgumentError`. This is the point — such code had a forgotten block and was already broken.

## Verification

- `bundle exec rake spec` — 162 examples, 0 failures
- `bundle exec rubocop` — 15 files, no offenses
- `bundle exec rbs validate` — passes