### PR TITLE
test: cover with_context block validation order

### DIFF
--- a/spec/retriable_spec.rb
+++ b/spec/retriable_spec.rb
@@ -1264,6 +1264,12 @@ describe Retriable do
       expect(@tries).to eq(0)
     end
 
+    it "checks for a block before looking up the context" do
+      expect { described_class.with_context(:missing) }
+        .to raise_error(ArgumentError, /with_context requires a block/)
+      expect(@tries).to eq(0)
+    end
+
     it "passes try count through to the context block" do
       seen_tries = []
 


### PR DESCRIPTION
## Summary

Adds a regression spec that locks in the ordering for `Retriable.with_context` validation: missing block is checked before context lookup.

## Why

`Retriable.with_context(:missing)` without a block should raise:

```ruby
ArgumentError, /with_context requires a block/
```

not the missing-context error. This preserves the intended consistency with `with_override` and catches a future regression that moves the block guard after context lookup.

## Verification

Red check against pre-fix commit `fc19152`:

- `bundle exec rspec spec/retriable_spec.rb -e "checks for a block before looking up the context"`
- Failed as expected with `missing not found in Retriable contexts...`

Green checks on this branch:

- `bundle exec rspec spec/retriable_spec.rb -e "checks for a block before looking up the context"` — 1 example, 0 failures
- `bundle exec rake spec` — 164 examples, 0 failures
- `bundle exec rubocop` — 15 files inspected, no offenses detected