### PR TITLE
perf: hoist backoff defaults into ExponentialBackoff::DEFAULTS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,14 @@
   contract is now called out in the `on_retry` documentation so handlers guard
   arithmetic or logging on `next_interval`.
 
+### Performance
+
+- `Config#initialize` no longer allocates a throwaway `ExponentialBackoff` (and
+  runs its redundant `validate!`) just to read default values. Defaults now live
+  in a frozen `ExponentialBackoff::DEFAULTS` constant, removing an allocation and
+  redundant validation from the `retriable` hot path.
+  ([#149](https://github.com/kamui/retriable/pull/149))
+
 ## 4.1.1
 
 ### Bug fixes

--- a/lib/retriable/config.rb
+++ b/lib/retriable/config.rb
@@ -21,13 +21,13 @@ module Retriable
     attr_accessor(*ATTRIBUTES)
 
     def initialize(opts = {})
-      backoff = ExponentialBackoff.new
+      defaults = ExponentialBackoff::DEFAULTS
 
-      @tries            = backoff.tries
-      @base_interval    = backoff.base_interval
-      @max_interval     = backoff.max_interval
-      @rand_factor      = backoff.rand_factor
-      @multiplier       = backoff.multiplier
+      @tries            = defaults[:tries]
+      @base_interval    = defaults[:base_interval]
+      @max_interval     = defaults[:max_interval]
+      @rand_factor      = defaults[:rand_factor]
+      @multiplier       = defaults[:multiplier]
       @sleep_disabled   = false
       @max_elapsed_time = 900 # 15 min
       @intervals        = nil

--- a/lib/retriable/exponential_backoff.rb
+++ b/lib/retriable/exponential_backoff.rb
@@ -14,14 +14,22 @@ module Retriable
       rand_factor
     ].freeze
 
+    DEFAULTS = {
+      tries: 3,
+      base_interval: 0.5,
+      max_interval: 60,
+      rand_factor: 0.5,
+      multiplier: 1.5
+    }.freeze
+
     attr_accessor(*ATTRIBUTES)
 
     def initialize(opts = {})
-      @tries         = 3
-      @base_interval = 0.5
-      @max_interval  = 60
-      @rand_factor   = 0.5
-      @multiplier    = 1.5
+      @tries         = DEFAULTS[:tries]
+      @base_interval = DEFAULTS[:base_interval]
+      @max_interval  = DEFAULTS[:max_interval]
+      @rand_factor   = DEFAULTS[:rand_factor]
+      @multiplier    = DEFAULTS[:multiplier]
 
       opts.each do |k, v|
         raise ArgumentError, "#{k} is not a valid option" if !ATTRIBUTES.include?(k)


### PR DESCRIPTION
## Problem

`Config#initialize` (lib/retriable/config.rb:24) built a full `ExponentialBackoff` just to read 5 default numbers (`tries`, `base_interval`, `max_interval`, `rand_factor`, `multiplier`). That construction also ran `ExponentialBackoff#validate!` on values that are compile-time constants and can never be invalid.

Because `Retriable.retriable(opts)` builds a fresh `Config` on **every** call when `opts` is non-empty or a `with_override` is active (lib/retriable.rb:58-62), this placed a wasted object allocation plus redundant validation on the hot path — with zero benefit, since `Config#validate!` already re-validates everything immediately before use.

## Change

- Add a frozen `ExponentialBackoff::DEFAULTS` hash as the single source of truth for backoff defaults.
- Read defaults from `DEFAULTS` in both `ExponentialBackoff#initialize` and `Config#initialize`, removing the throwaway `ExponentialBackoff.new`.

Behavior is unchanged: defaults are identical and `Config#validate!` still runs.

## Verification

- `bundle exec rake`: 164 examples, 0 failures; rubocop 15 files, no offenses.
- Allocation micro-benchmark (`ObjectSpace.count_objects[:T_OBJECT]` over 1000 `Config.new`):
  - Before: **2.0** per `Config.new` (Config + throwaway ExponentialBackoff)
  - After: **1.0** per `Config.new`