### PR TITLE
Snapshot with_override opts to prevent caller mutation leaking into active override

### DIFF
--- a/lib/retriable.rb
+++ b/lib/retriable.rb
@@ -29,6 +29,7 @@ module Retriable
     raise ArgumentError, "empty override options are not allowed" if opts.empty?
     raise ArgumentError, "with_override requires a block" unless block_given?
 
+    opts = snapshot_override_options(opts)
     validate_override_options(opts)
 
     previous = Thread.current.thread_variable_get(OVERRIDE_THREAD_KEY)
@@ -232,6 +233,24 @@ module Retriable
     merged
   end
 
+  # Isolate the caller's override hash from later mutation. We shallow-dup the
+  # top level and dup :contexts two levels deep (the contexts Hash and each
+  # per-context options Hash) because that is the documented nesting depth.
+  # Values (procs like :on_retry, exception classes in :on, regexps) are shared
+  # by reference and deliberately not duplicated — a Marshal deep-dup would raise
+  # on Proc. Note: :on and :intervals values are shared by reference (only
+  # :contexts is deep-dupped) per the scope of this fix.
+  def snapshot_override_options(opts)
+    snapshot = opts.dup
+    contexts = snapshot[:contexts]
+    if contexts.is_a?(Hash)
+      snapshot[:contexts] = contexts.each_with_object({}) do |(key, value), acc|
+        acc[key] = value.is_a?(Hash) ? value.dup : value
+      end
+    end
+    snapshot
+  end
+
   def available_contexts
     config_contexts.merge(override_contexts)
   end
@@ -274,6 +293,7 @@ module Retriable
     :hash_exception_match?,
     :apply_override_options,
     :merge_layer,
+    :snapshot_override_options,
     :available_contexts,
     :context_options_for,
     :config_contexts,

--- a/lib/retriable.rb
+++ b/lib/retriable.rb
@@ -237,7 +237,7 @@ module Retriable
   # top level and dup :contexts two levels deep (the contexts Hash and each
   # per-context options Hash) because that is the documented nesting depth.
   # Values (procs like :on_retry, exception classes in :on, regexps) are shared
-  # by reference and deliberately not duplicated — a Marshal deep-dup would raise
+  # by reference and deliberately not duplicated - a Marshal deep-dup would raise
   # on Proc. Note: :on and :intervals values are shared by reference (only
   # :contexts is deep-dupped) per the scope of this fix.
   def snapshot_override_options(opts)

--- a/spec/retriable_spec.rb
+++ b/spec/retriable_spec.rb
@@ -1114,6 +1114,12 @@ describe Retriable do
       described_class.with_override(opts) do
         opts[:contexts][:api][:tries] = 99 # mutate nested per-context options
         opts[:contexts][:added] = { tries: 99 } # add a new context
+
+        # The added context must not leak into the snapshotted override, proving
+        # the outer :contexts hash itself was duplicated (not just its values).
+        expect { described_class.with_context(:added) { :noop } }
+          .to raise_error(ArgumentError, /added not found/)
+
         begin
           described_class.with_context(:api) do
             tries += 1

--- a/spec/retriable_spec.rb
+++ b/spec/retriable_spec.rb
@@ -1087,6 +1087,64 @@ describe Retriable do
         expect(@tries).to eq(2)
       end
     end
+
+    it "snapshots opts so top-level mutation during the block does not change the override" do
+      opts = { tries: 1 }
+      tries = 0
+
+      described_class.with_override(opts) do
+        opts[:tries] = 99 # caller mutates their own hash mid-flight
+        begin
+          described_class.retriable do
+            tries += 1
+            raise StandardError
+          end
+        rescue StandardError
+          # swallow; we only care about attempt count
+        end
+      end
+
+      expect(tries).to eq(1)
+    end
+
+    it "snapshots :contexts so nested mutation during the block does not change the override" do
+      opts = { contexts: { api: { tries: 1 } } }
+      tries = 0
+
+      described_class.with_override(opts) do
+        opts[:contexts][:api][:tries] = 99 # mutate nested per-context options
+        opts[:contexts][:added] = { tries: 99 } # add a new context
+        begin
+          described_class.with_context(:api) do
+            tries += 1
+            raise StandardError
+          end
+        rescue StandardError
+          # swallow
+        end
+      end
+
+      expect(tries).to eq(1)
+    end
+
+    it "preserves procs and exception classes in the override snapshot" do
+      retry_calls = 0
+      on_retry = proc { retry_calls += 1 }
+
+      described_class.with_override(tries: 2, on: { StandardError => nil }, on_retry: on_retry) do
+        described_class.retriable do
+          raise StandardError
+        end
+      rescue StandardError
+        # swallow
+      end
+
+      # on_retry fires on every failed attempt, including the final one (see
+      # lib/retriable.rb on_retry/on_give_up contract), so tries: 2 => 2 calls.
+      # The point of this test is that the proc survives the snapshot and is
+      # still invoked (and the StandardError key in :on still matches).
+      expect(retry_calls).to eq(2)
+    end
   end
 
   context "#with_override thread safety" do


### PR DESCRIPTION
## Problem

`Retriable.with_override(opts)` stored the caller's `opts` hash **by reference** in the thread-local override slot. Retriable itself never mutates that hash (all reads go through non-mutating `Hash#merge`), but the caller still holds the same object and can mutate it while the block runs — directly inside the block, or from a sibling thread/fiber that shares the reference (fibers in a thread intentionally share the override). That would change override behavior mid-flight. As a secondary effect, `validate_override_options` runs *before* the value was stored, so post-entry mutation also bypassed validation.

## Fix

Snapshot the caller's options at the start of `with_override`, before validation:

- New private helper `snapshot_override_options(opts)` — shallow-dups the top-level hash and dups `:contexts` two levels deep (the contexts Hash and each per-context options Hash, the documented nesting depth).
- Values that must stay shared by reference (procs like `:on_retry`/`:retry_if`/`:on_give_up`, exception classes in `:on`, regexps) are **not** duplicated. A `Marshal`-based deep dup is deliberately avoided because it raises on `Proc`.
- `:on` and `:intervals` values remain shared by reference — out of scope for this change (documented in the helper comment); only `:contexts` is deep-dupped.

## Tests

Three regression tests added under `#with_override`:

1. Top-level mutation during the block does not change the override.
2. Nested `:contexts` mutation (mutating a per-context option and adding a new context) during the block does not change the override.
3. Procs and exception classes survive the snapshot (guards against a future Marshal-style deep-dup regression).

## Verification

- `bundle exec rspec` → 167 examples, 0 failures
- `bundle exec rubocop lib/retriable.rb spec/retriable_spec.rb` → no offenses