### PR TITLE
Strengthen with_override immutability contract in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,8 +248,13 @@ do not inherit it. This makes `#with_override` safe to use in parallel test
 runners. Fibers running inside the same thread share the thread's active
 override.
 
-`#with_override` stores the provided options directly. Do not mutate the
-options hash or nested values for the duration of the block.
+`#with_override` stores the provided options hash **by reference** and reads
+from it on every attempt while the block runs. Treat the hash and all of its
+nested values as immutable for the duration of the block: do not mutate them
+from inside the block, and do not mutate them from another thread or fiber that
+shares this thread's active override. Mutating the options mid-block results in
+undefined retry behavior. If options must be computed, build the hash before
+calling `#with_override` and do not retain a reference you will later mutate.
 
 For test-integration patterns (RSpec `around`, helper methods, Minitest, etc.),
 see [docs/testing.md](docs/testing.md).


### PR DESCRIPTION
## Why

`Retriable.with_override` stores the caller's options hash **by reference** and re-reads it on every retry attempt while the block runs. The README already told callers not to mutate the options, but it didn't explain *why* or cover the full blast radius. This was raised as a potential bug (caller mutating the hash mid-block, or from a sibling fiber, changing override behavior mid-flight).

After review, the by-reference storage is intended, documented behavior (the immutability note dates back to #121, the commit that introduced `with_override`). A runtime snapshot was considered and rejected: `with_override` is primarily a test helper, and a partial dup (e.g. only `:contexts`) would give a false sense of completeness while leaving `:on`/`:intervals` shared. Strengthening the documented contract covers every nested value at zero runtime cost.

## Change

Clarify the existing contract note in the README Override section:

- State explicitly that options are stored **by reference** and read on **every attempt**.
- Use stronger framing ("treat the hash and all nested values as immutable").
- Name the cross-thread/fiber vector, consistent with the thread-safety paragraph above it.
- State the consequence (undefined retry behavior).
- Give the safe pattern: build the hash before calling `#with_override`; don't retain a reference you will later mutate.

Documentation-only; no behavior change.