### PR TITLE
Release 4.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,23 @@
-# HEAD
+## 4.2.0
+
+### Thread safety
+
+- `Retriable.configure` is now copy-on-write and thread-safe. The global config
+  is eagerly initialized at load time (closing an init race where concurrent
+  boot could create two `Config` objects), and `configure` now mutates a `dup`
+  under a mutex before atomically publishing it. Readers on the `retriable` fast
+  path always observe a single consistent snapshot instead of a live config that
+  another thread could be mutating mid-read (torn reads). `configure` still does
+  not validate; validation remains lazy at `retriable`-call time.
+- `Config#dup` now deep-copies its mutable members (`on`, `intervals`,
+  `contexts`) via `initialize_copy`, so a duplicated config is fully isolated
+  from the original. Scalars, procs, and exception classes stay shared by
+  reference. This underpins the copy-on-write `configure`.
+- `Retriable.with_context` now captures a single config snapshot and threads it
+  through context existence checking and option resolution. Previously it read
+  the published config multiple times, so a concurrent `configure` between reads
+  could pass the existence check on the old snapshot while options resolved
+  against the new one, silently dropping the context's retry options.
 
 ### Bug fixes
 

--- a/lib/retriable.rb
+++ b/lib/retriable.rb
@@ -15,14 +15,37 @@ module Retriable
   RetryPlan = Struct.new(:max_tries, :interval_for)
   private_constant :RetryPlan
 
+  # Serializes #configure so concurrent read-modify-write swaps cannot drop one
+  # another's updates. Reads of @config stay lock-free: #configure only ever
+  # publishes a brand-new, never-mutated Config via an atomic reference assignment.
+  CONFIG_MUTEX = Mutex.new
+  private_constant :CONFIG_MUTEX
+
+  # Eagerly initialized at load time. `require` is serialized in MRI, so this runs
+  # exactly once before any thread can reach #config/#configure, closing the
+  # `@config ||= Config.new` check-then-act race.
+  @config = Config.new
+
   module_function
 
+  # Copy-on-write: dup the published config, let the caller mutate the copy, then
+  # atomically publish it. Readers therefore always observe a consistent,
+  # fully-applied snapshot, and a failed/raising block leaves the old config
+  # intact. Does NOT validate (validation stays lazy at #retriable time).
+  # NOTE: CONFIG_MUTEX is non-reentrant — do not call #configure from within a
+  # configure block.
   def configure
-    yield(config)
+    CONFIG_MUTEX.synchronize do
+      new_config = (@config ||= Config.new).dup
+      yield(new_config)
+      @config = new_config
+    end
   end
 
+  # Lock-free read of the eagerly-published config. The guarded fallback only runs
+  # if @config was explicitly reset to nil (e.g. the test suite's before(:each)).
   def config
-    @config ||= Config.new
+    @config || CONFIG_MUTEX.synchronize { @config ||= Config.new }
   end
 
   def with_override(opts = {})

--- a/lib/retriable.rb
+++ b/lib/retriable.rb
@@ -66,14 +66,15 @@ module Retriable
   def with_context(context_key, options = {}, &)
     raise ArgumentError, "with_context requires a block" unless block_given?
 
-    contexts = available_contexts
+    config_snapshot = config
+    contexts = available_contexts(config_snapshot)
 
     if !contexts.key?(context_key)
       raise ArgumentError,
             "#{context_key} not found in Retriable contexts (including overrides). Available contexts: #{contexts.keys}"
     end
 
-    retriable(context_options_for(context_key, options), &)
+    retriable(context_options_for(context_key, options, config_snapshot), &)
   end
 
   def retriable(opts = {}, &)
@@ -255,12 +256,12 @@ module Retriable
     merged
   end
 
-  def available_contexts
-    config_contexts.merge(override_contexts)
+  def available_contexts(config_snapshot)
+    config_contexts(config_snapshot).merge(override_contexts)
   end
 
-  def context_options_for(context_key, options)
-    context_options = config_contexts.fetch(context_key, {})
+  def context_options_for(context_key, options, config_snapshot)
+    context_options = config_contexts(config_snapshot).fetch(context_key, {})
     context_options = {} unless context_options.is_a?(Hash)
     context_options = merge_layer(context_options, options)
 
@@ -270,8 +271,8 @@ module Retriable
     apply_override_options(context_options, override_context_options)
   end
 
-  def config_contexts
-    config.contexts.is_a?(Hash) ? config.contexts : {}
+  def config_contexts(config_snapshot)
+    config_snapshot.contexts.is_a?(Hash) ? config_snapshot.contexts : {}
   end
 
   def override_contexts

--- a/lib/retriable/config.rb
+++ b/lib/retriable/config.rb
@@ -70,6 +70,23 @@ module Retriable
 
     private
 
+    def initialize_copy(other)
+      super
+      @on        = dup_collection(other.on)
+      @intervals = other.intervals&.dup
+      @contexts  = dup_contexts(other.contexts)
+    end
+
+    def dup_collection(value)
+      value.is_a?(Array) || value.is_a?(Hash) || value.is_a?(Set) ? value.dup : value
+    end
+
+    def dup_contexts(contexts)
+      return contexts unless contexts.is_a?(Hash)
+
+      contexts.transform_values { |options| options.is_a?(Hash) ? options.dup : options }
+    end
+
     def validate_backoff_options
       validate_non_negative_number(:base_interval, base_interval)
       validate_non_negative_number(:multiplier, multiplier)

--- a/lib/retriable/version.rb
+++ b/lib/retriable/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Retriable
-  VERSION = "4.1.1"
+  VERSION = "4.2.0"
 end

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -180,4 +180,41 @@ describe Retriable::Config do
       end
     end
   end
+
+  context "#dup (copy-on-write isolation)" do
+    it "deep-copies contexts so mutating the copy leaves the original intact" do
+      original = described_class.new(contexts: { sql: { tries: 1 } })
+      copy = original.dup
+
+      copy.contexts[:http] = { tries: 2 }
+      copy.contexts[:sql][:tries] = 99
+
+      expect(original.contexts).to eq(sql: { tries: 1 })
+    end
+
+    it "deep-copies on and intervals collections" do
+      original = described_class.new(on: [StandardError], intervals: [1, 2])
+      copy = original.dup
+
+      copy.on << ArgumentError
+      copy.intervals << 3
+
+      expect(original.on).to eq([StandardError])
+      expect(original.intervals).to eq([1, 2])
+    end
+
+    it "preserves a non-collection on value (Exception class) without duping it" do
+      original = described_class.new(on: StandardError)
+      expect(original.dup.on).to be(StandardError)
+    end
+
+    it "deep-copies a Hash on value so the copy is a distinct hash" do
+      original = described_class.new(on: { StandardError => /boom/ })
+      copy = original.dup
+
+      copy.on[ArgumentError] = /other/
+
+      expect(original.on).to eq(StandardError => /boom/)
+    end
+  end
 end

--- a/spec/retriable_spec.rb
+++ b/spec/retriable_spec.rb
@@ -1357,5 +1357,21 @@ describe Retriable do
 
       expect(callback_called).to be(true)
     end
+
+    it "resolves the context against a single config snapshot" do
+      with_ctx = Retriable::Config.new(sleep_disabled: true, contexts: { api: { tries: 1 } })
+      without_ctx = Retriable::Config.new(sleep_disabled: true)
+
+      # Simulate a concurrent #configure publishing a new config between
+      # with_context's existence check and its option resolution: the first
+      # config read sees the context, later reads do not. with_context must
+      # read config once so the context options are never silently dropped.
+      allow(described_class).to receive(:config).and_return(with_ctx, without_ctx)
+
+      expect { described_class.with_context(:api) { increment_tries_with_exception } }
+        .to raise_error(StandardError)
+
+      expect(@tries).to eq(1)
+    end
   end
 end

--- a/spec/retriable_spec.rb
+++ b/spec/retriable_spec.rb
@@ -770,6 +770,51 @@ describe Retriable do
     end
   end
 
+  context "#configure thread safety (copy-on-write)" do
+    it "eagerly initializes @config at load time, before any configure/config call" do
+      script = "require 'retriable'; " \
+               "exit(Retriable.instance_variable_get(:@config).is_a?(Retriable::Config) ? 0 : 1)"
+      expect(system(RbConfig.ruby, "-Ilib", "-e", script)).to be(true)
+    end
+
+    it "publishes a new Config object on configure instead of mutating in place" do
+      before = described_class.config
+      described_class.configure { |c| c.tries = 7 }
+      after = described_class.config
+
+      expect(after).not_to equal(before)
+      expect(after.tries).to eq(7)
+      expect(before.tries).not_to eq(7)
+    end
+
+    it "keeps an already-captured snapshot stable across later configures" do
+      described_class.configure { |c| c.contexts[:sql] = { tries: 1 } }
+      snapshot = described_class.config
+
+      described_class.configure { |c| c.contexts[:http] = { tries: 2 } }
+      described_class.configure { |c| c.contexts[:sql][:tries] = 99 }
+
+      expect(snapshot.contexts).to eq(sql: { tries: 1 })
+    end
+
+    it "does not drop updates when configured concurrently from many threads" do
+      keys = (0...50).map { |i| :"ctx_#{i}" }
+      release = Queue.new
+
+      threads = keys.map do |key|
+        Thread.new do
+          release.pop
+          described_class.configure { |c| c.contexts[key] = { tries: 1 } }
+        end
+      end
+
+      keys.size.times { release << true }
+      threads.each(&:join)
+
+      expect(described_class.config.contexts.keys).to match_array(keys)
+    end
+  end
+
   context "#retriable tries/intervals precedence" do
     it "lets a per-call tries clear globally configured intervals" do
       described_class.configure { |c| c.intervals = [0.5, 1.0] }


### PR DESCRIPTION
## Release 4.2.0

Prepares the 4.2.0 release. This includes the thread-safe / copy-on-write
config work and bumps the gem version.

### Version
- `Retriable::VERSION` `4.1.1` → `4.2.0`
- `CHANGELOG.md`: `# HEAD` promoted to `## 4.2.0` with a new **Thread safety** section

### Thread safety (from #151)
- `Retriable.configure` is now copy-on-write and thread-safe: the global config is
  eagerly initialized at load time (closing an init race) and `configure` mutates a
  `dup` under a mutex before atomically publishing. Readers on the `retriable` fast
  path always see a single consistent snapshot (no torn reads). Validation stays lazy.
- `Config#dup` deep-copies its mutable members (`on`, `intervals`, `contexts`) via
  `initialize_copy`; scalars/procs/exception classes stay shared by reference.
- `Retriable.with_context` captures a single config snapshot threaded through context
  existence checking and option resolution, so a concurrent `configure` can no longer
  silently drop a context's retry options.

### Verification
- `bundle exec rake` → 172 examples, 0 failures
- RuboCop → 15 files, no offenses

> Note: this PR is based on `main` and therefore includes the commits from #151.
> Merging this supersedes #151.
