### PR TITLE
Validate context structure in Config#validate!

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,14 @@
   Previously a missing block was silently ignored: the call returned `nil` and
   the intended block never ran, hiding a caller bug. Behavior change: code that
   relied on the silent no-op will now raise.
+- `Config#validate!` now validates the structure of each entry in `contexts`,
+  so configured contexts are checked on every `Retriable.retriable`/
+  `with_context` call rather than only when a given context is first used. A
+  context whose options contain an unknown key (including a nested `contexts`
+  key) now raises `ArgumentError, "<key> is not a valid option"`, matching the
+  `with_override` path. Non-Hash `contexts` and non-Hash per-context values
+  remain leniently treated as empty options (no behavior change). Option
+  *values* are still validated lazily at retry time, unchanged.
 
 ### Docs
 

--- a/lib/retriable/config.rb
+++ b/lib/retriable/config.rb
@@ -18,6 +18,9 @@ module Retriable
       contexts
     ]).freeze
 
+    CONTEXT_ATTRIBUTES = (ATTRIBUTES - %i[contexts]).freeze
+    private_constant :CONTEXT_ATTRIBUTES
+
     attr_accessor(*ATTRIBUTES)
 
     def initialize(opts = {})
@@ -51,6 +54,7 @@ module Retriable
     end
 
     def validate!
+      validate_contexts
       validate_callable(:retry_if, retry_if)
       validate_callable(:on_retry, on_retry)
       validate_callable(:on_give_up, on_give_up)
@@ -69,6 +73,21 @@ module Retriable
     end
 
     private
+
+    def validate_contexts
+      return unless contexts.is_a?(Hash)
+      return if contexts.empty?
+
+      contexts.each_value do |options|
+        next unless options.is_a?(Hash)
+
+        options.each_key do |k|
+          next if CONTEXT_ATTRIBUTES.include?(k)
+
+          raise ArgumentError, "#{k} is not a valid option"
+        end
+      end
+    end
 
     def validate_backoff_options
       validate_non_negative_number(:base_interval, base_interval)

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -180,4 +180,33 @@ describe Retriable::Config do
       end
     end
   end
+
+  context "context structure validation" do
+    it "rejects a context whose options contain a nested :contexts key" do
+      expect { described_class.new(contexts: { api: { contexts: {} } }) }
+        .to raise_error(ArgumentError, /contexts is not a valid option/)
+    end
+
+    it "rejects a context with an unknown option key" do
+      expect { described_class.new(contexts: { api: { does_not_exist: 1 } }) }
+        .to raise_error(ArgumentError, /does_not_exist is not a valid option/)
+    end
+
+    it "validates context structure even when intervals is provided" do
+      expect { described_class.new(intervals: [0.1], contexts: { api: { contexts: {} } }) }
+        .to raise_error(ArgumentError, /contexts is not a valid option/)
+    end
+
+    it "accepts a non-Hash context value (treated as empty options)" do
+      expect { described_class.new(contexts: { broken: nil }) }.not_to raise_error
+    end
+
+    it "accepts nil contexts" do
+      expect { described_class.new(contexts: nil) }.not_to raise_error
+    end
+
+    it "accepts a valid context" do
+      expect { described_class.new(contexts: { api: { tries: 3, base_interval: 1.0 } }) }.not_to raise_error
+    end
+  end
 end

--- a/spec/retriable_spec.rb
+++ b/spec/retriable_spec.rb
@@ -1307,6 +1307,13 @@ describe Retriable do
       expect(@tries).to eq(1)
     end
 
+    it "surfaces an invalid context on any retriable call before that context is used" do
+      described_class.configure { |c| c.contexts[:unused] = { contexts: {} } }
+
+      expect { described_class.retriable { :ok } }
+        .to raise_error(ArgumentError, /contexts is not a valid option/)
+    end
+
     it "invokes on_give_up configured on a context" do
       callback_called = false
       described_class.configure do |c|


### PR DESCRIPTION
## Summary

`Config#validate!` validated top-level options but never recursed into `contexts`. Two consequences:

1. **Correctness bug:** a context's options could contain a nested `:contexts` key, which was silently accepted (`:contexts` is a valid `Config` attribute) and ignored — diverging from the `with_override` path, which explicitly rejects it.
2. **Timing:** other invalid context keys only surfaced when that specific context was first exercised via `with_context`, not when the config was otherwise used.

This adds a structural check for `contexts` to `validate!`. Each context's option keys must be valid `Config` attributes excluding `:contexts`; an invalid key raises `ArgumentError, "<key> is not a valid option"`, matching the override path exactly. Because `validate!` runs on every `retriable`/`with_context` call, structural errors now surface on any call rather than only when the offending context is used.

## Scope / non-goals

- **Option *values* remain validated lazily** at retry time (e.g. `tries: "lots"` is unchanged) — consistent with the override path and top-level lazy validation.
- **Lenient inputs preserved:** non-Hash `contexts` and non-Hash per-context values are still treated as empty options (no new rejections). Regression-covered by existing specs (`contexts = nil`, `contexts[:broken] = nil`).
- Override path (`lib/retriable.rb`) left untouched.

## Performance

Allowed keys hoisted to a frozen `CONTEXT_ATTRIBUTES` constant (no per-call allocation) and validation early-returns on empty/non-Hash `contexts`, so the default/common path adds a single `empty?` check.

## Tests

- `spec/config_spec.rb`: rejects nested `:contexts`, rejects unknown keys, runs even when `intervals` is set (placement regression), accepts non-Hash values / `nil` / valid contexts.
- `spec/retriable_spec.rb`: invalid context surfaces on a plain `retriable` call before the context is used.
- Full suite: 171 examples, 0 failures. RuboCop clean.
